### PR TITLE
Aircraft module code refactoring

### DIFF
--- a/Scripts/DCS-BIOS/BIOS.lua
+++ b/Scripts/DCS-BIOS/BIOS.lua
@@ -20,6 +20,15 @@ package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\?.lua;]] .. package.path
 package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\?.lua;]] .. package.path
 package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\io\?.lua;]] .. package.path
 
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\io\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\modules\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\modules\aircraft_modules\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\modules\common_modules\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\modules\documentation\?.lua;]] .. package.path
+package.path = lfs.writedir() .. [[Scripts\DCS-BIOS\lib\modules\memory_map\?.lua;]] .. package.path
+
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Util.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\ProtocolIO.lua]])
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Protocol.lua]])
@@ -32,7 +41,10 @@ dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\TextDisplay.lua]])
 -- Following text: Example (case sensitive!): -- ID = x, ProperName = <pretty name>
 -- is used by DCSFlightpanels GUI to pick up DCS-BIOS modules
 -- ID range 1-3 is used internally in DCSFlightpanels. New modules must have an uniques ID.
-dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\A-4E-C.lua]]) -- ID = 6, ProperName = A-4E Skyhawk
+local A_4E_C = require "A-4E-C"
+BIOS.protocol.writeNewModule(A_4E_C)
+
+-- dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\A-4E-C.lua]]) -- ID = 6, ProperName = A-4E Skyhawk
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\A-10C.lua]]) -- ID = 5, ProperName = A-10C Thunderbolt/II
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\A-29B.lua]]) -- ID = 41, ProperName = A-29B Super Tucano
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\AH-6J.lua]]) -- ID = 7, ProperName = AH-6J Littlebird
@@ -69,7 +81,9 @@ dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Mig-21Bis.lua]]) -- ID = 32, Prope
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\Mosquito.lua]]) -- ID = 45, ProperName = Mosquito FB Mk. VI
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\NS430.lua]]) -- ID = 33, ProperName = NS 430 GPS
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\P-47D.lua]]) -- ID = 34, ProperName = P-47D Thunderbolt
-dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\P-51D.lua]]) -- ID = 35, ProperName = TF/P-51D Mustang
+-- dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\P-51D.lua]]) -- ID = 35, ProperName = TF/P-51D Mustang
+local P_51D = require "P-51D"
+BIOS.protocol.writeNewModule(P_51D)
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\SA342.lua]]) -- ID = 36, ProperName = SA342 Gazelle
 dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\SpitfireLFMkIX.lua]]) -- ID = 37, ProperName = Spitfire LF Mk. IX
 --dofile(lfs.writedir()..[[Scripts\DCS-BIOS\lib\SuperCarrier.lua]])

--- a/Scripts/DCS-BIOS/lib/Protocol.lua
+++ b/Scripts/DCS-BIOS/lib/Protocol.lua
@@ -145,6 +145,12 @@ function BIOS.protocol.endModule()
 	moduleBeingDefined = nil
 	end
 end
+function BIOS.protocol.writeNewModule(mod)
+	moduleBeingDefined = mod
+	exportModules[mod.name] = mod
+	BIOS.protocol.setExportModuleAircrafts(mod.aircraftList)
+	BIOS.protocol.endModule()
+end
 
 local metadataStartModule = nil
 local metadataEndModule = nil

--- a/Scripts/DCS-BIOS/lib/modules/Module.lua
+++ b/Scripts/DCS-BIOS/lib/modules/Module.lua
@@ -1,0 +1,652 @@
+module("Module", package.seeall)
+
+local ActionArgument = require("ActionArgument")
+local ActionInput = require("ActionInput")
+local ApiVariant = require("ApiVariant")
+local Control = require("Control")
+local ControlType = require("ControlType")
+local Documentation = require("Documentation")
+local FixedStepInput = require("FixedStepInput")
+local IntegerOutput = require("IntegerOutput")
+local MemoryMap = require("MemoryMap")
+local MomentaryPositions = require("MomentaryPositions")
+local PhysicalVariant = require("PhysicalVariant")
+local SetStateInput = require("SetStateInput")
+local StringOutput = require("StringOutput")
+local Suffix = require("Suffix")
+local VariableStepInput = require("VariableStepInput")
+
+--- @class Module
+--- @field name string the name of the module
+--- @field documentation Documentation TODO
+--- @field inputProcessors { [string]: fun(value: string | integer) } functions to run on receiving data
+--- @field memoryMap MemoryMap a map of all memory allocations for sending and receiving data
+--- @field exportHooks fun(value: any)[] functions to run on sending data
+--- @field aircraftList string[] list of aircraft ids to export to
+local Module = {}
+
+--- Constructs a new module
+--- @param name string the name of the module
+--- @param baseAddress number the starting address for all controls in this module
+--- @param acftList string[] any aircraft this modules should map to
+function Module:new(name, baseAddress, acftList)
+	--- @type Module
+	local o = {
+		name = name,
+		documentation = Documentation:new(),
+		inputProcessors = {},
+		memoryMap = MemoryMap:new(baseAddress),
+		exportHooks = {},
+		aircraftList = acftList,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+
+	return o
+end
+
+--- Defines a gauge from floating-point data with limits
+--- @param identifier string the unique identifier for the control
+--- @param arg_number integer the dcs argument number
+--- @param limits number[] a length-2 array with the lower and upper bounds of the data as used in dcs
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineFloat(identifier, arg_number, limits, category, description)
+	local intervalLength = limits[2] - limits[1]
+	local max_value = 65535
+	local alloc = self.memoryMap:allocateInt(max_value)
+
+	self:addExportHook(function(dev0)
+		alloc:setValue(((dev0:get_argument_value(arg_number) - limits[1]) / intervalLength) * max_value)
+	end)
+
+	-- todo: almost identical to below for allocating an int, just different descriptions?
+	local control = Control:new(category, ControlType.analog_gauge, identifier, description, {}, {
+		IntegerOutput:new(alloc, Suffix.none, "gauge position"),
+	})
+	self:addControl(control)
+
+	return control
+end
+
+--- Adds a new indicator light control
+--- @param identifier string the unique identifier for the control
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineIndicatorLight(identifier, arg_number, category, description)
+	local value = self.memoryMap:allocateInt(1)
+
+	assert(value.shiftBy ~= nil)
+	self:addExportHook(function(dev0)
+		if dev0:get_argument_value(arg_number) < 0.3 then
+			value:setValue(0)
+		else
+			value:setValue(1)
+		end
+	end)
+
+	local control = Control:new(category, ControlType.led, identifier, description, {}, {
+		IntegerOutput:new(value, Suffix.none, "0 if light is off, 1 if light is on"),
+	})
+	self:addControl(control)
+
+	return control
+end
+
+--- Adds a new push button control
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:definePushButton(identifier, device_id, command, arg_number, category, description)
+	local control =
+		self:defineTumb(identifier, device_id, command, arg_number, 1, { 0, 1 }, nil, false, category, description)
+	control.physical_variant = PhysicalVariant.push_button
+	control.api_variant = ApiVariant.momentary_last_position
+
+	return control
+end
+
+--- Adds a new rotary potentiometer with values between 0 and 65535
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param limits number[] a length-2 array with the lower and upper bounds of the data as used in dcs
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:definePotentiometer(identifier, device_id, command, arg_number, limits, category, description)
+	local max_value = 65535
+	if limits == nil then
+		limits = { 0, 1 }
+	end
+	local intervalLength = limits[2] - limits[1]
+	self:addInputProcessor(identifier, function(value)
+		local newValue = ((GetDevice(0):get_argument_value(arg_number) - limits[1]) / intervalLength) * max_value
+		if value:match("-[0-9]+") or value:match("%+[0-9]+") then
+			newValue = Module.cap(newValue + tonumber(value), 0, max_value)
+		elseif value:match("[0-9]+") then
+			newValue = Module.cap(tonumber(value) or 0, 0, max_value)
+		end
+
+		GetDevice(device_id):performClickableAction(command, newValue / max_value * intervalLength + limits[1])
+	end)
+
+	local value = self.memoryMap:allocateInt(max_value)
+
+	self:addExportHook(function(dev0)
+		value:setValue(((dev0:get_argument_value(arg_number) - limits[1]) / intervalLength) * max_value)
+	end)
+
+	local control = Control:new(category, ControlType.limited_dial, identifier, description, {
+		SetStateInput:new(max_value, "set the position of the dial"),
+		VariableStepInput:new(3200, max_value, "turn the dial left or right"),
+	}, {
+		IntegerOutput:new(value, Suffix.none, "position of the potentiometer"),
+	})
+	self:addControl(control)
+
+	return control
+end
+
+--- Adds a two-position toggle switch
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineToggleSwitch(identifier, device_id, command, arg_number, category, description)
+	local control =
+		self:defineTumb(identifier, device_id, command, arg_number, 1, { 0, 1 }, nil, false, category, description)
+	control.physical_variant = PhysicalVariant.toggle_switch
+
+	return control
+end
+
+--- Adds an n-position switch
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param num_positions integer the number of positions the switch has
+--- @param increment number the amount to increment the dcs data by with each step of the switch
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineMultipositionSwitch(
+	identifier,
+	device_id,
+	command,
+	arg_number,
+	num_positions,
+	increment,
+	category,
+	description
+)
+	local control = self:defineTumb(
+		identifier,
+		device_id,
+		command,
+		arg_number,
+		increment,
+		{ 0, increment * (num_positions - 1) },
+		nil,
+		false,
+		category,
+		description
+	)
+	control.physical_variant = PhysicalVariant.toggle_switch
+
+	return control
+end
+
+--- Adds an infitely-looping rotary, like an encoder
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineRotary(identifier, device_id, command, arg_number, category, description)
+	local max_value = 65535
+	self:addInputProcessor(identifier, function(value)
+		GetDevice(device_id):performClickableAction(command, tonumber(value) / max_value)
+	end)
+
+	local value = self.memoryMap:allocateInt(max_value)
+
+	local control = Control:new(category, ControlType.analog_dial, identifier, description, {
+		VariableStepInput:new(3200, max_value, "turn the dial left or right"),
+	}, {
+		IntegerOutput:new(
+			value,
+			Suffix.knob_pos,
+			"the rotation of the knob in the cockpit (not the value that is controlled by this knob!)"
+		),
+	}, nil, nil, ApiVariant.multiturn)
+	self:addControl(control)
+
+	self:addExportHook(function(dev0)
+		value:setValue(dev0:get_argument_value(arg_number) * max_value)
+	end)
+
+	return control
+end
+
+--- Adds a 3-position toggle switch with dcs data values between -1 and 1
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:define3PosTumb(identifier, device_id, command, arg_number, category, description)
+	local control =
+		self:defineTumb(identifier, device_id, command, arg_number, 1, { -1, 1 }, nil, false, category, description)
+	control.physical_variant = PhysicalVariant.three_position_switch
+
+	return control
+end
+
+--- Adds a fixed-step rotary device
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param step number the amount to increase or decrease dcs data by with each step
+--- @param limits number[] a length-2 array with the lower and upper bounds of the data as used in dcs
+--- @param rel_args number[] a length-2 array with the data to send to dcs on fixed-step inputs as [DEC, INC]
+--- @param output_map string[]? an array of string values to output for inputs across the range of values, or nil if none
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineFixedStepTumb(
+	identifier,
+	device_id,
+	command,
+	arg_number,
+	step,
+	limits,
+	rel_args,
+	output_map,
+	category,
+	description
+)
+	local control = self:defineTumb(
+		identifier,
+		device_id,
+		command,
+		arg_number,
+		step,
+		limits,
+		output_map,
+		true,
+		category,
+		description
+	)
+	assert(control.inputs[2].interface == "set_state") -- todo: type if necessary
+	control.inputs[2] = nil
+	control.control_type = ControlType.discrete_dial
+
+	self:addFixedStepInputProcessor(identifier, device_id, command, rel_args[1], rel_args[2])
+
+	return control
+end
+
+--- Adds a fixed-step infinitely-looping rotary which may only be incremented or decremented
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param rel_args number[] a length-2 array with the data to send to dcs on fixed-step inputs as [DEC, INC]
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineFixedStepInput(identifier, device_id, command, rel_args, category, description)
+	self:addFixedStepInputProcessor(identifier, device_id, command, rel_args[1], rel_args[2])
+	local control = Control:new(category, ControlType.fixed_step_dial, identifier, description, {
+		FixedStepInput:new("turn left or right"),
+	}, {
+		-- these have no output as their position is effectively irrelevant - they loop infinitely
+	})
+	self:addControl(control)
+
+	return control
+end
+
+--- @private
+--- Adds a fixed-step input processor
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param decrement_value number the data to send to dcs when the step is decremented
+--- @param increment_value number the data to send to dcs when the step is incremented
+function Module:addFixedStepInputProcessor(identifier, device_id, command, decrement_value, increment_value)
+	self:addTwoCommandFixedStepInputProcessor(identifier, device_id, command, command, decrement_value, increment_value)
+end
+
+--- @private
+--- Adds a fixed-step input processor
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param decrement_command integer the dcs command when decrementing
+--- @param increment_command integer the dcs command when incrementing
+--- @param decrement_value number the data to send to dcs when the step is decremented
+--- @param increment_value number the data to send to dcs when the step is incremented
+function Module:addTwoCommandFixedStepInputProcessor(
+	identifier,
+	device_id,
+	decrement_command,
+	increment_command,
+	decrement_value,
+	increment_value
+)
+	self:addInputProcessor(identifier, function(state)
+		if state == "DEC" then
+			GetDevice(device_id):performClickableAction(decrement_command, decrement_value)
+		elseif state == "INC" then
+			GetDevice(device_id):performClickableAction(increment_command, increment_value)
+		end
+	end)
+end
+
+--- Defines a two-command fixed-step rotary input
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param decrement_command integer the dcs command when decrementing
+--- @param increment_command integer the dcs command when incrementing
+--- @param rel_args number[] a length-2 array with the data to send to dcs on fixed-step inputs as [DEC, INC]
+--- @param arg_number integer the dcs argument number
+--- @param step number the amount to increase or decrease dcs data by with each step
+--- @param limits number[] a length-2 array with the lower and upper bounds of the data as used in dcs
+--- @param output_map string[]? an array of string values to output for inputs across the range of values, or nil if none
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineRadioWheel(
+	identifier,
+	device_id,
+	decrement_command,
+	increment_command,
+	rel_args,
+	arg_number,
+	step,
+	limits,
+	output_map,
+	category,
+	description
+)
+	local control = self:defineTumb(
+		identifier,
+		device_id,
+		decrement_command,
+		arg_number,
+		step,
+		limits,
+		output_map,
+		"skiplast",
+		category,
+		description
+	)
+	assert(control.inputs[2].interface == "set_state")
+	control.inputs[2] = nil
+	control.control_type = ControlType.discrete_dial
+
+	self:addTwoCommandFixedStepInputProcessor(
+		identifier,
+		device_id,
+		decrement_command,
+		increment_command,
+		rel_args[1],
+		rel_args[2]
+	)
+
+	return control
+end
+
+--- Adds a new integer output based on a custom getter function
+--- @param identifier string the unique identifier for the control
+--- @param getter fun(): integer the getter function which will return an integer
+--- @param maxValue integer the maximum value the getter will return
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineIntegerFromGetter(identifier, getter, maxValue, category, description)
+	local alloc = self.memoryMap:allocateInt(maxValue)
+	self:addExportHook(function(_)
+		alloc:setValue(getter())
+	end)
+
+	local control = Control:new(category, ControlType.metadata, identifier, description, {}, {
+		IntegerOutput:new(alloc, Suffix.none, description),
+	})
+	self:addControl(control)
+
+	return control
+end
+
+-- todo: this will be fun. this god function needs to be refactored
+--- Capable of adding pretty much every fixed-step input in the game, apparently
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param step number the amount to increase or decrease dcs data by with each step
+--- @param limits number[] a length-2 array with the lower and upper bounds of the data as used in dcs
+--- @param output_map string[]? an array of string values to output for inputs across the range of values, or nil if none
+--- @param cycle boolean | "skiplast" true if infinite rotary, false if limited rotary, skiplast functionality unclear
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineTumb(
+	identifier,
+	device_id,
+	command,
+	arg_number,
+	step,
+	limits,
+	output_map,
+	cycle,
+	category,
+	description
+)
+	local span = limits[2] - limits[1]
+	local last_n = tonumber(string.format("%.0f", span / step))
+	assert(last_n)
+
+	local value_enum = output_map
+	if not value_enum then
+		value_enum = {}
+		local n = 0
+		while n <= last_n do
+			value_enum[#value_enum + 1] = tostring(n)
+			n = n + 1
+		end
+	end
+
+	-- todo: the A-10C is the sole user of the "skiplast" cycle argument
+	--  also apparently anything with radio wheel
+	--  It's unclear if that should affect allocateInt.maxValue, so we'll leave that for the future
+	local max_value = last_n - (cycle == "skiplast" and 1 or 0)
+	local enumAlloc = self.memoryMap:allocateInt(max_value)
+	local strAlloc = nil
+	if output_map then
+		local max_len = 0
+		for i = 1, #output_map, 1 do
+			if max_len < output_map[i]:len() then
+				max_len = output_map[i]:len()
+			end
+		end
+		strAlloc = self.memoryMap:allocateString(max_len)
+	end
+	self:addExportHook(function(dev0)
+		local value = dev0:get_argument_value(arg_number)
+		local n = tonumber(string.format("%.0f", (value - limits[1]) / step))
+
+		if n > last_n then
+			n = last_n
+		end
+		if n == last_n and cycle == "skiplast" then
+			n = 0
+		end
+		enumAlloc:setValue(n)
+		if output_map and strAlloc then
+			strAlloc:setValue(output_map[n + 1])
+		end
+	end)
+
+	local inputs = {
+		FixedStepInput:new("switch to previous or next state"),
+		SetStateInput:new(max_value, "set position"),
+	}
+
+	if last_n == 1 then
+		table.insert(inputs, ActionInput:new(ActionArgument.toggle, "Toggle switch state"))
+	end
+
+	local int_output_suffix = output_map and strAlloc and Suffix.int or Suffix.none
+
+	local outputs = {
+		IntegerOutput:new(enumAlloc, int_output_suffix, "selector position"),
+	}
+
+	if output_map and strAlloc then
+		local output_description = "possible values:"
+		for i = 1, #output_map, 1 do
+			output_description = string.format([[%s "%s"]], output_description, output_map[i])
+		end
+
+		table.insert(outputs, StringOutput:new(strAlloc, Suffix.str, output_description))
+	end
+
+	local variant = cycle and PhysicalVariant.infinite_rotary or PhysicalVariant.limited_rotary
+
+	local control = Control:new(
+		category,
+		ControlType.selector,
+		identifier,
+		description,
+		inputs,
+		outputs,
+		MomentaryPositions.none,
+		variant
+	)
+
+	self:addControl(control)
+
+	self:addInputProcessor(identifier, function(state)
+		local value = GetDevice(0):get_argument_value(arg_number)
+		local n = tonumber(string.format("%.0f", (value - limits[1]) / step))
+		local new_n = n
+		if state == "INC" then
+			new_n = Module.cap(n + 1, 0, last_n, cycle)
+			if cycle == "skiplast" and new_n == last_n then
+				new_n = 0
+			end
+
+			GetDevice(device_id):performClickableAction(command, limits[1] + step * new_n)
+		elseif state == "DEC" then
+			new_n = Module.cap(n - 1, 0, last_n, cycle)
+			if cycle == "skiplast" and new_n == last_n then
+				new_n = last_n - 1
+			end
+
+			GetDevice(device_id):performClickableAction(command, limits[1] + step * new_n)
+		elseif state == "TOGGLE" then
+			if n == 0 then
+				new_n = 1
+			elseif n == 1 then
+				new_n = 0
+			end
+			GetDevice(device_id):performClickableAction(command, limits[1] + step * new_n)
+		else
+			n = tonumber(string.format("%.0f", tonumber(state)))
+			if n == nil then
+				return
+			end
+			GetDevice(device_id):performClickableAction(command, limits[1] + step * Module.cap(n, 0, last_n, cycle))
+		end
+	end)
+
+	return control
+end
+
+--- @private
+--- Adds an export hook to the module
+--- @param func fun(dev0: CockpitDevice) callback function called when exporting data, provided with device 0
+function Module:addExportHook(func)
+	table.insert(self.exportHooks, func)
+end
+
+--- @private
+--- adds an input processor to the module
+--- @param msg string
+--- @param func fun(value: string | integer)
+function Module:addInputProcessor(msg, func)
+	self.inputProcessors[msg] = func
+end
+
+--- @private
+--- @param control Control
+function Module:addControl(control)
+	local category = self.documentation:getOrAddCategory(control.category)
+
+	-- todo: move this further down?
+	if control.outputs then
+		for _, output in ipairs(control.outputs) do
+			output.address_identifier = self:addressDefineIdentifier(control.identifier)
+			output.address_only_identifier = self:addressDefineIdentifier(control.identifier) .. "_ADDR"
+		end
+	end
+
+	category:addControl(control)
+end
+
+--- Creates a full identifier, including the module name, for a given identifier
+--- @param identifier string
+--- @return string
+function Module:addressDefineIdentifier(identifier)
+	local full_identifier = self.name .. "_" .. identifier
+	full_identifier = full_identifier:gsub("[^A-Za-z0-9_]", "_") -- Replace all characters that are not A-Z, a-z, 0-9, or _ with _
+	full_identifier = full_identifier:gsub("_+", "_") -- Replace successive underscores with a single _
+
+	return full_identifier
+end
+
+--- Returns a vlue that is between the limits provided
+--- @param value integer the value to cap
+--- @param min_value integer the minimum value to return
+--- @param max_value integer the maximum value to return
+--- @param cycle boolean | "skiplast" | nil whether to roll values over which are outside the bounds (so values below min return max and vice-versa)
+--- @return integer
+function Module.cap(value, min_value, max_value, cycle)
+	if cycle then
+		if value < min_value then
+			return max_value
+		end
+		if value > max_value then
+			return min_value
+		end
+	else
+		if value <= min_value then
+			return min_value
+		end
+		if value >= max_value then
+			return max_value
+		end
+	end
+	return value
+end
+
+return Module

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-4E-C.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-4E-C.lua
@@ -1,0 +1,515 @@
+module("A_4E_C", package.seeall)
+
+local Module = require("Module")
+
+--- @class A_4E_C: Module
+local A_4E_C = Module:new("A-4E-C", 0x8400, { "A-4E-C" })
+
+--v 3.2 by WarLord & Dehuman
+
+--Engine gauges
+A_4E_C:defineFloat("RPM", 520, { 0, 1 }, "Engine Instruments", "Engine RPM")
+A_4E_C:defineFloat("RPM_DECI", 521, { 0, 1 }, "Engine Instruments", "Engine RPM DECI")
+A_4E_C:defineFloat("EGT_C", 540, { 0, 1 }, "Engine Instruments", "EGT")
+A_4E_C:defineFloat("D_FUEL_FLOW", 560, { 0, 1 }, "Engine Instruments", "Fuel Flow")
+A_4E_C:defineFloat("OIL_PRESSURE", 152, { 0, 1 }, "Engine Instruments", "Oil Pressure")
+A_4E_C:defineFloat("PRESSURE_RATIO", 151, { 0, 1 }, "Engine Instruments", "Pressure Ratio")
+A_4E_C:defineFloat("D_FUEL", 580, { 0, 1 }, "Engine Instruments", "Fuel Gauge")
+
+--Hook, flaps, gear
+A_4E_C:defineFloat("D_FLAPS_IND", 23, { 0, 1 }, "Mechanical Systems Indicators", "Flaps Indicator")
+A_4E_C:defineFloat("D_TAIL_HOOK", 10, { 0, 1 }, "Mechanical Systems Indicators", "Hook Indicator")
+A_4E_C:defineFloat("GEAR_NOSE", 20, { 0, 1 }, "Mechanical Systems Indicators", "Nose Gear Indicator")
+A_4E_C:defineFloat("GEAR_LEFT", 21, { 0, 1 }, "Mechanical Systems Indicators", "Left Gear Indicator")
+A_4E_C:defineFloat("GEAR_RIGHT", 22, { 0, 1 }, "Mechanical Systems Indicators", "Right Gear Indicator")
+
+--Main Flight Instruments
+A_4E_C:defineFloat("ATTGYRO_STBY_HORIZ", 665, { -1, 1 }, "Main Flight Instruments", "SAI Horizon")
+A_4E_C:defineFloat("ATTGYRO_STBY_PITCH", 660, { -1, 1 }, "Main Flight Instruments", "SAI Pitch")
+A_4E_C:defineFloat("ATTGYRO_STBY_ROLL", 661, { -1, 1 }, "Main Flight Instruments", "SAI Roll")
+A_4E_C:defineFloat("ATTGYRO_STBY_OFF", 664, { 0, 1 }, "Main Flight Instruments", "SAI Off")
+A_4E_C:defineFloat("D_IAS_DEG", 880, { 0, 1 }, "Main Flight Instruments", "IAS")
+A_4E_C:defineFloat("D_IAS_MACH_DEG", 881, { 0, 1 }, "Main Flight Instruments", "Mach Disc")
+A_4E_C:defineFloat("D_IAS_IDX", 882, { 0, 1 }, "Main Flight Instruments", "IAS Index")
+A_4E_C:defineFloat("D_MACH_IDX", 883, { 0, 1 }, "Main Flight Instruments", "Mach Index")
+A_4E_C:defineFloat("D_RADAR_ALT", 600, { 0, 1 }, "Main Flight Instruments", "Radar Altimeter")
+A_4E_C:defineFloat("D_RADAR_IDX", 601, { 0, 1 }, "Main Flight Instruments", "Radar ALtimeter Indexer")
+A_4E_C:defineFloat("D_RADAR_OFF", 604, { 0, 1 }, "Main Flight Instruments", "Radar Altimeter Off flag")
+A_4E_C:defineFloat("D_ALT_NEEDLE", 820, { 0, 1 }, "Main Flight Instruments", "Altimeter needle")
+A_4E_C:defineFloat("D_ALT_10K", 821, { 0, 1 }, "Main Flight Instruments", "Altimeter 10k")
+A_4E_C:defineFloat("D_ALT_1K", 822, { 0, 1 }, "Main Flight Instruments", "Altimeter 1k")
+A_4E_C:defineFloat("D_ALT_100S", 823, { 0, 1 }, "Main Flight Instruments", "Altimeter 100s")
+A_4E_C:defineFloat("ALT_ADJ_NN00", 824, { 0, 1 }, "Main Flight Instruments", "Altimeter Adjustment NNxx")
+A_4E_C:defineFloat("ALT_ADJ_00N0", 825, { 0, 1 }, "Main Flight Instruments", "Altimeter Adjustment xxNx")
+A_4E_C:defineFloat("ALT_ADJ_000N", 826, { 0, 1 }, "Main Flight Instruments", "Altimeter Adjustment xxxN")
+A_4E_C:defineFloat("CABIN_ALT", 710, { 0, 1 }, "Main Flight Instruments", "Cabin Altitude")
+A_4E_C:defineFloat("LIQUID_O2", 760, { 0, 1 }, "Main Flight Instruments", "Liquid Oxygen")
+A_4E_C:defineFloat("D_OXYGEN_OFF", 762, { 0, 1 }, "Main Flight Instruments", "Oxygen off flag")
+A_4E_C:defineFloat("ACCEL_CUR", 360, { -1, 1 }, "Main Flight Instruments", "Accelerometer")
+A_4E_C:defineFloat("ACCEL_MAX", 137, { -1, 1 }, "Main Flight Instruments", "Accelerometer Max")
+A_4E_C:defineFloat("ACCEL_MIN", 138, { -1, 1 }, "Main Flight Instruments", "Accelerometer Min")
+A_4E_C:defineFloat("VVI", 800, { -1, 1 }, "Main Flight Instruments", "Variometer")
+A_4E_C:defineFloat("ADI_PITCH", 383, { -1, 1 }, "Main Flight Instruments", "ADI Pitch")
+A_4E_C:defineFloat("ADI_ROLL", 384, { -1, 1 }, "Main Flight Instruments", "ADI Roll")
+A_4E_C:defineFloat("ADI_HDG", 385, { -1, 1 }, "Main Flight Instruments", "ADI Heading")
+A_4E_C:defineFloat("ADI_OFF", 387, { 0, 1 }, "Main Flight Instruments", "ADI Off")
+A_4E_C:defineFloat("ADI_SLIP", 388, { -1, 1 }, "Main Flight Instruments", "ADI Slip")
+A_4E_C:defineFloat("ADI_TURN", 389, { -1, 1 }, "Main Flight Instruments", "ADI Turn")
+A_4E_C:defineFloat("COMPASS_HDG", 148, { -1, 1 }, "Main Flight Instruments", "Backup Compass")
+A_4E_C:defineFloat("AOA_G", 840, { 0, 1 }, "Main Flight Instruments", "Angle Of Attack")
+
+--Gunsight
+A_4E_C:defineFloat("D_GUNSIGHT_REFLECTOR", 894, { 0, 1 }, "Gunsight", "Gunsight Reflector Elevation")
+
+--Caution Light ladder
+A_4E_C:defineIndicatorLight("D_FUELBOOST_CAUTION", 860, "Warning Lamps", "Fuel Boost-Caution Ladder (yellow)")
+A_4E_C:defineIndicatorLight("D_CONTHYD_CAUTION", 861, "Warning Lamps", "Control Hydraulics-Caution Ladder (yellow)")
+A_4E_C:defineIndicatorLight("D_UTILHYD_CAUTION", 862, "Warning Lamps", "Utility Hydraulics-Caution Ladder (yellow)")
+A_4E_C:defineIndicatorLight("D_FUELTRANS_CAUTION", 863, "Warning Lamps", "Fuel Transfer-Caution Ladder (yellow)")
+A_4E_C:defineIndicatorLight("D_SPDBRK_CAUTION", 864, "Warning Lamps", "Speed Break-Caution Ladder (yellow)")
+A_4E_C:defineIndicatorLight("D_SPOILER_CAUTION", 865, "Warning Lamps", "Spoiler-Caution Ladder (yellow)")
+
+--BDHI
+A_4E_C:defineFloat("BDHI_HDG", 780, { 0, 1 }, "BDHI", "BDHI Heading")
+A_4E_C:defineFloat("BDHI_NEEDLE1", 781, { 0, 1 }, "BDHI", "BDHI Needle 1")
+A_4E_C:defineFloat("BDHI_NEEDLE2", 782, { 0, 1 }, "BDHI", "BDHI Needle 2")
+A_4E_C:defineFloat("BDHI_DME_FLAG", 786, { 0, 1 }, "BDHI", "BDHI Flag")
+A_4E_C:defineFloat("BDHI_DME_X00", 785, { 0, 1 }, "BDHI", "BDHI Xnn")
+A_4E_C:defineFloat("BDHI_DME_0X0", 784, { 0, 1 }, "BDHI", "BDHI nXn")
+A_4E_C:defineFloat("BDHI_DME_00X", 783, { 0, 1 }, "BDHI", "BDHI nnX")
+A_4E_C:defineFloat("BDHI_ILS_GS", 381, { -1, 1 }, "BDHI", "BDHI ILS GS")
+A_4E_C:defineFloat("BDHI_ILS_LOC", 382, { -1, 1 }, "BDHI", "BDHI ILS LOC")
+
+--WARN LAMPS
+A_4E_C:defineIndicatorLight("D_RADAR_WARN", 605, "Warning Lamps", "Radar Altitude Warning (red)")
+A_4E_C:defineIndicatorLight("D_OIL_LOW", 150, "Warning Lamps", "Oil Low Light (yellow)")
+A_4E_C:defineIndicatorLight("D_GLARE_WHEELS", 154, "Warning Lamps", "Glareshield Wheels (white)")
+A_4E_C:defineIndicatorLight("D_GLARE_LABS", 155, "Warning Lamps", "Glareshield LABS (yellow)")
+A_4E_C:defineIndicatorLight("D_RADAR_WARN", 156, "Warning Lamps", "Glareshield LAWS (red)")
+A_4E_C:defineIndicatorLight("D_GLARE_OBST", 157, "Warning Lamps", "Glareshield OBST (yellow)")
+A_4E_C:defineIndicatorLight("D_GLARE_IFF", 158, "Warning Lamps", "Glareshield IFF (white)")
+A_4E_C:defineIndicatorLight("D_GLARE_FIRE", 159, "Warning Lamps", "Glareshield Fire (red)")
+A_4E_C:defineIndicatorLight("D_OXYGEN_LOW", 761, "Warning Lamps", "Oxygen Low (red)")
+
+--LAMPS
+A_4E_C:defineIndicatorLight("GEAR_LIGHT", 27, "Mechanical Systems", "Landing Gear Light (red)")
+A_4E_C:defineIndicatorLight("AOA_GREEN", 850, "AOA Indicator", "AOA Indexer (green)")
+A_4E_C:defineIndicatorLight("AOA_YELLOW", 851, "AOA Indicator", "AOA Indexer (yellow)")
+A_4E_C:defineIndicatorLight("AOA_RED", 852, "AOA Indicator", "AOA Indexer (red)")
+A_4E_C:defineIndicatorLight("AWRS_POWER", 741, "Armament Panel", "AWRS Power Indicator Light (yellow)")
+A_4E_C:defineIndicatorLight("APC_LIGHT", 147, "ApproachPowerCompensator", "APC Indicator Light (red)")
+A_4E_C:defineIndicatorLight("D_ADVISORY_INRANGE", 866, "Advisory Lights", "In Range Light (yellow)")
+A_4E_C:defineIndicatorLight("D_ADVISORY_SETRANGE", 867, "Advisory Lights", "Set Range Light (yellow)")
+A_4E_C:defineIndicatorLight("D_ADVISORY_DIVE", 868, "Advisory Lights", "Dive Light (yellow)")
+
+--Radar Scope
+A_4E_C:defineFloat("APG53A_LEFTRANGE", 406, { 0, 1 }, "Radar Control Panel Gauges", "Radar Profile Range")
+A_4E_C:defineFloat("APG53A_BOTTOMRANGE", 407, { 0, 1 }, "Radar Control Panel Gauges", "Radar Plan Range")
+A_4E_C:defineFloat("AFCS_HDG_100S", 167, { 0, 1 }, "AFCS", "AFCS Heading 100's")
+A_4E_C:defineFloat("AFCS_HDG_10S", 168, { 0, 1 }, "AFCS", "AFCS Heading 10's")
+A_4E_C:defineFloat("AFCS_HDG_1S", 169, { 0, 1 }, "AFCS", "AFCS Heading 1's")
+
+-- APN-153 Doppler Radar
+A_4E_C:defineIndicatorLight("APN153_MEMORYLIGHT", 171, "Doppler Nav Lights", "Memory Light (yellow)")
+A_4E_C:defineFloat("APN153_DRIFT_GAUGE", 172, { -1, 1 }, "Doppler Nav", "Drift Gauge")
+A_4E_C:defineFloat("APN153_SPEED_X00", 173, { 0, 1 }, "Doppler Nav", "Speed Xnn")
+A_4E_C:defineFloat("APN153_SPEED_0X0", 174, { 0, 1 }, "Doppler Nav", "Speed nXn")
+A_4E_C:defineFloat("APN153_SPEED_00X", 175, { 0, 1 }, "Doppler Nav", "Speed nnX")
+A_4E_C:defineFloat("NAV_CURPOS_LAT_X0000", 178, { 0, 1 }, "Doppler Nav Position", "Current Latitude Xnnnn")
+A_4E_C:defineFloat("NAV_CURPOS_LAT_0X000", 179, { 0, 1 }, "Doppler Nav Position", "Current Latitude nXnnn")
+A_4E_C:defineFloat("NAV_CURPOS_LAT_00X00", 180, { 0, 1 }, "Doppler Nav Position", "Current Latitude nnXnn")
+A_4E_C:defineFloat("NAV_CURPOS_LAT_000X0", 181, { 0, 1 }, "Doppler Nav Position", "Current Latitude nnnXn")
+A_4E_C:defineFloat("NAV_CURPOS_LAT_0000X", 182, { 0, 1 }, "Doppler Nav Position", "Current Latitude nnnnX")
+A_4E_C:defineFloat("NAV_CURPOS_LON_X00000", 184, { 0, 1 }, "Doppler Nav Position", "Current Longitude Xnnnnn")
+A_4E_C:defineFloat("NAV_CURPOS_LON_0X0000", 185, { 0, 1 }, "Doppler Nav Position", "Current Longitude nXnnnn")
+A_4E_C:defineFloat("NAV_CURPOS_LON_00X000", 186, { 0, 1 }, "Doppler Nav Position", "Current Longitude nnXnnn")
+A_4E_C:defineFloat("NAV_CURPOS_LON_000X00", 187, { 0, 1 }, "Doppler Nav Position", "Current Longitude nnnXnn")
+A_4E_C:defineFloat("NAV_CURPOS_LON_0000X0", 188, { 0, 1 }, "Doppler Nav Position", "Current Longitude nnnnXn")
+A_4E_C:defineFloat("NAV_CURPOS_LON_00000X", 189, { 0, 1 }, "Doppler Nav Position", "Current Longitude nnnnnX")
+
+A_4E_C:defineFloat("NAV_DEST_LAT_X0000", 191, { 0, 1 }, "Doppler Nav Destination", "Destination Latitude Xnnnn")
+A_4E_C:defineFloat("NAV_DEST_LAT_0X000", 192, { 0, 1 }, "Doppler Nav Destination", "Destination Latitude nXnnn")
+A_4E_C:defineFloat("NAV_DEST_LAT_00X00", 193, { 0, 1 }, "Doppler Nav Destination", "Destination Latitude nnXnn")
+A_4E_C:defineFloat("NAV_DEST_LAT_000X0", 194, { 0, 1 }, "Doppler Nav Destination", "Destination Latitude nnnXn")
+A_4E_C:defineFloat("NAV_DEST_LAT_0000X", 195, { 0, 1 }, "Doppler Nav Destination", "Destination Latitude nnnnX")
+A_4E_C:defineFloat("NAV_DEST_LON_X00000", 197, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude Xnnnnn")
+A_4E_C:defineFloat("NAV_DEST_LON_0X0000", 198, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude nXnnnn")
+A_4E_C:defineFloat("NAV_DEST_LON_00X000", 199, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude nnXnnn")
+A_4E_C:defineFloat("NAV_DEST_LON_000X00", 200, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude nnnXnn")
+A_4E_C:defineFloat("NAV_DEST_LON_0000X0", 201, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude nnnnXn")
+A_4E_C:defineFloat("NAV_DEST_LON_00000X", 202, { 0, 1 }, "Doppler Nav Destination", "Destination Longitude nnnnnX")
+
+A_4E_C:defineFloat("ASN41_WINDSPEED_X00", 210, { 0, 1 }, "Doppler Nav", "Windspeed Xnn")
+A_4E_C:defineFloat("ASN41_WINDSPEED_0X0", 211, { 0, 1 }, "Doppler Nav", "Windspeed nXn")
+A_4E_C:defineFloat("ASN41_WINDSPEED_00X", 212, { 0, 1 }, "Doppler Nav", "Windspeed nnX")
+A_4E_C:defineFloat("ASN41_WINDDIR_X00", 214, { 0, 1 }, "Doppler Nav", "Wind Direction Xnn")
+A_4E_C:defineFloat("ASN41_WINDDIR_0X0", 215, { 0, 1 }, "Doppler Nav", "Wind Direction nXn")
+A_4E_C:defineFloat("ASN41_WINDDIR_00X", 216, { 0, 1 }, "Doppler Nav", "Wind Direction nnX")
+A_4E_C:defineFloat("ASN41_MAGVAR_X0000", 204, { 0, 1 }, "Doppler Nav", "MagVar Xnnnn")
+A_4E_C:defineFloat("ASN41_MAGVAR_0X000", 205, { 0, 1 }, "Doppler Nav", "MagVar nXnnn")
+A_4E_C:defineFloat("ASN41_MAGVAR_00X00", 206, { 0, 1 }, "Doppler Nav", "MagVar nnXnn")
+A_4E_C:defineFloat("ASN41_MAGVAR_000X0", 207, { 0, 1 }, "Doppler Nav", "MagVar nnnXn")
+A_4E_C:defineFloat("ASN41_MAGVAR_0000X", 208, { 0, 1 }, "Doppler Nav", "MagVar nnnnX")
+
+-- COUNTERMEASURES
+A_4E_C:defineFloat("CM_BANK1_X0", 526, { 0, 1 }, "Countermeasures", "CM Bank 1 10's")
+A_4E_C:defineFloat("CM_BANK1_0X", 527, { 0, 1 }, "Countermeasures", "CM Bank 1 1's")
+A_4E_C:defineFloat("CM_BANK2_X0", 528, { 0, 1 }, "Countermeasures", "CM Bank 2 10's")
+A_4E_C:defineFloat("CM_BANK2_0X", 529, { 0, 1 }, "Countermeasures", "CM Bank 2 1's")
+
+-- AN/ARC-51 UHF Radio
+A_4E_C:defineFloat("ARC51_FREQ_XX000", 362, { 0, 1 }, "UHF Radio", "Frequency XXnnn")
+A_4E_C:defineFloat("ARC51_FREQ_00X00", 363, { 0, 1 }, "UHF Radio", "Frequency nnXnn")
+A_4E_C:defineFloat("ARC51_FREQ_000XX", 364, { 0, 0.95 }, "UHF Radio", "Frequency nnnXX")
+A_4E_C:defineFloat("ARC51_FREQ_PRESET", 371, { 0, 0.95 }, "UHF Radio", "Frequency Preset")
+
+--Cockpit Lights
+A_4E_C:defineFloat("LIGHTS_FLOOD_WHITE", 111, { 0, 0.75 }, "Lights", "White Flood Lights (white)")
+A_4E_C:defineFloat("LIGHTS_FLOOD_RED", 114, { 0, 1 }, "Lights", "Red Flood Lights (red)")
+A_4E_C:defineFloat("LIGHTS_INSTRUMENTS", 117, { 0, 1 }, "Lights", "Instrument Lights (red)")
+A_4E_C:defineFloat("LIGHTS_CONSOLE", 119, { 0, 1 }, "Lights", "Console Lights (red)")
+A_4E_C:defineFloat("APG53A_GLOW", 115, { 0, 1 }, "Lights", "Radar Glow Light (green)")
+
+--Clock
+A_4E_C:defineFloat("CURRTIME_HOURS", 440, { 0, 1 }, "Clock", "Current Hours")
+A_4E_C:defineFloat("CURRTIME_MINS", 441, { 0, 1 }, "Clock", "Current Minutes")
+A_4E_C:defineFloat("CURRTIME_SECS", 442, { 0, 1 }, "Clock", "Current Seconds")
+A_4E_C:defineFloat("STOPWATCH_MINS", 144, { 0, 1 }, "Clock", "Stopwatch Minutes")
+A_4E_C:defineFloat("STOPWATCH_SECS", 145, { 0, 1 }, "Clock", "Stopwatch Seconds")
+
+--ECM Panel
+A_4E_C:defineIndicatorLight("RWR_LIGHT", 373, "ECM Panel Lights", "Glareshield RWR Light")
+A_4E_C:defineIndicatorLight("ECM_TEST_LIGHT", 514, "ECM Panel Lights", "ECM Test Light (white)")
+A_4E_C:defineIndicatorLight("ECM_GO_LIGHT", 515, "ECM Panel Lights", "ECM GO Light (green)")
+A_4E_C:defineIndicatorLight("ECM_NOGO_LIGHT", 516, "ECM Panel Lights", "ECM NO GO Light (red)")
+A_4E_C:defineIndicatorLight("ECM_SAM_LIGHT", 517, "ECM Panel Lights", "ECM SAM Light (red)")
+A_4E_C:defineIndicatorLight("ECM_RPT_LIGHT", 518, "ECM Panel Lights", "ECM RPT Light (green)")
+A_4E_C:defineIndicatorLight("ECM_STBY_LIGHT", 519, "ECM Panel Lights", "ECM STBY Light (yellow)")
+A_4E_C:defineIndicatorLight("ECM_REC_LIGHT", 500, "ECM Panel Lights", "ECM REC Light (red)")
+
+A_4E_C:defineFloat("CANOPY_POS", 26, { 0, 1 }, "Mechanical Systems", "Canopy Position")
+
+------CONTROLS
+-- RADAR CONTROL PANEL
+A_4E_C:defineMultipositionSwitch("RADAR_MODE", 10, 3063, 120, 5, 0.10, "Radar Control Panel", "Radar Mode")
+A_4E_C:defineToggleSwitch("RADAR_AOACOMP", 10, 3064, 121, "Radar Control Panel", "Radar AoA Compensation")
+A_4E_C:definePotentiometer("RADAR_ANGLE", 10, 3065, 122, { 0, 1 }, "Radar Control Panel", "Radar Antenna Tilt")
+A_4E_C:definePotentiometer("RADAR_VOL", 10, 3068, 123, { -1, 1 }, "Radar Control Panel", "Radar Obstacle Tone Volume")
+
+-- RADAR SCOPE
+A_4E_C:definePotentiometer("RADAR_STORAGE", 10, 3057, 400, { -1, 1 }, "Radar Scope", "Radar Indicator Storage")
+A_4E_C:definePotentiometer("RADAR_BRILLIANCE", 10, 3058, 401, { -1, 1 }, "Radar Scope", "Radar Indicator Brilliance")
+A_4E_C:definePotentiometer("RADAR_DETAIL", 10, 3059, 402, { -1, 1 }, "Radar Scope", "Radar Indicator Detail")
+A_4E_C:definePotentiometer("RADAR_GAIN", 10, 3060, 403, { -1, 1 }, "Radar Scope", "Radar Indicator Gain")
+A_4E_C:definePotentiometer("RADAR_RETICLE", 10, 3062, 404, { -1, 1 }, "Radar Scope", "Radar Indicator Reticle")
+A_4E_C:defineToggleSwitch("RADAR_FILTER", 10, 3061, 405, "Radar Scope", "Radar Indicator Filter Plate")
+
+--Gunpods
+A_4E_C:define3PosTumb("GUNPOD_CLEAR", 6, 3012, 390, "Gunpods", "Gunpod Charge/Off/Clear")
+A_4E_C:defineToggleSwitch("GUNPOD_L", 6, 3009, 391, "Gunpods", "Gunpod Station LH Switch")
+A_4E_C:defineToggleSwitch("GUNPOD_C", 6, 3010, 392, "Gunpods", "Gunpod Station CTR Switch")
+A_4E_C:defineToggleSwitch("GUNPOD_R", 6, 3011, 393, "Gunpods", "Gunpod Station RH Switch")
+
+--Countermeasures
+A_4E_C:define3PosTumb("CM_BANK", 32, 3106, 522, "Countermeasures", "CM Bank Select")
+A_4E_C:definePushButton("CM_AUTO", 32, 3107, 523, "Countermeasures", "CM Auto Pushbutton")
+A_4E_C:defineRotary("CM_ADJ1", 32, 3108, 524, "Countermeasures", "CM Bank 1 Adjust")
+A_4E_C:defineRotary("CM_ADJ2", 32, 3109, 525, "Countermeasures", "CM Bank 2 Adjust")
+A_4E_C:defineToggleSwitch("CM_PWR", 32, 3110, 530, "Countermeasures", "CM Power Toggle")
+
+--Armament Panel
+A_4E_C:defineMultipositionSwitch("ARM_EMERG_SEL", 6, 3025, 700, 7, 0.1, "Armament Panel", "Emergency Release Selector")
+A_4E_C:defineToggleSwitch("ARM_GUN", 6, 3001, 701, "Armament Panel", "Guns Switch")
+A_4E_C:define3PosTumb("ARM_BOMB", 6, 3026, 702, "Armament Panel", "Bomb arm switch")
+A_4E_C:defineToggleSwitch("ARM_STATION1", 6, 3003, 703, "Armament Panel", "Station 1 select")
+A_4E_C:defineToggleSwitch("ARM_STATION2", 6, 3004, 704, "Armament Panel", "Station 2 select")
+A_4E_C:defineToggleSwitch("ARM_STATION3", 6, 3005, 705, "Armament Panel", "Station 3 select")
+A_4E_C:defineToggleSwitch("ARM_STATION4", 6, 3006, 706, "Armament Panel", "Station 4 select")
+A_4E_C:defineToggleSwitch("ARM_STATION5", 6, 3007, 707, "Armament Panel", "Station 5 select")
+A_4E_C:defineMultipositionSwitch("ARM_FUNC_SEL", 6, 3008, 708, 7, 0.1, "Armament Panel", "Function Selector")
+A_4E_C:defineMultipositionSwitch("AWRS_QUANT", 6, 3031, 740, 12, 0.05, "Armament Panel", "AWRS Quantity Selector")
+A_4E_C:definePotentiometer("AWRS_DROP_INT", 6, 3032, 742, { 0, 0.9 }, "Armament Panel", "AWRS Drop Interval")
+A_4E_C:defineToggleSwitch("AWRS_MULTI", 6, 3033, 743, "Armament Panel", "AWRS Multiplier")
+A_4E_C:defineMultipositionSwitch("AWRS_MODE", 6, 3034, 744, 6, 0.1, "Armament Panel", "AWRS mode")
+A_4E_C:defineToggleSwitch("ARM_MASTER", 3, 3002, 709, "Armament Panel", "Master Armament")
+A_4E_C:defineToggleSwitch("RADAR_PROFILE", 10, 3055, 721, "Radar Scope", "Radar Plan/Profile")
+A_4E_C:defineToggleSwitch("RADAR_RANGE", 10, 3056, 722, "Radar Scope", "Radar Long/Short Range")
+A_4E_C:define3PosTumb("BDHI_MODE", 23, 3044, 724, "BDHI", "BDHI mode")
+A_4E_C:defineMultipositionSwitch("SHRIKE_SEL_KNB", 6, 3137, 725, 5, 0.1, "Armament Panel", "Shrike Selector Knob")
+A_4E_C:definePotentiometer("MISSILE_VOL", 6, 3125, 726, { -1, 1 }, "Armament Panel", "Missile Volume Knob")
+
+--AFCS Panel
+A_4E_C:defineToggleSwitch("AFCS_STBY", 27, 3088, 160, "AFCS", "AFCS Standby")
+A_4E_C:defineToggleSwitch("AFCS_ENGAGE", 27, 3089, 161, "AFCS", "AFCS Engage")
+A_4E_C:defineToggleSwitch("AFCS_HDG_SEL", 27, 3090, 162, "AFCS", "AFCS Preselect Heading")
+A_4E_C:defineToggleSwitch("AFCS_ALT", 27, 3091, 163, "AFCS", "AFCS Altitude Hold")
+A_4E_C:defineRotary("AFCS_HDG_SET", 27, 3092, 164, "AFCS", "AFCS Heading Selector")
+A_4E_C:defineToggleSwitch("AFCS_STAB_AUG", 27, 3093, 165, "AFCS", "AFCS Stability Aug")
+A_4E_C:defineToggleSwitch("AFCS_AIL_TRIM", 27, 3094, 166, "AFCS", "AFCS Aileron Trim")
+
+--Approach Power Compensator
+A_4E_C:define3PosTumb("APC_ENABLE", 27, 3095, 135, "ApproachPowerCompensator", "APC Enable/Stby/Off")
+A_4E_C:define3PosTumb("APS_COLD_STD_HOT", 27, 3096, 136, "ApproachPowerCompensator", "APC Cold/Std/Hot")
+
+--Mechanical Systems
+A_4E_C:defineToggleSwitch("GEAR_HANDLE", 15, 3020, 8, "Mechanical Systems", "Landing Gear Handle")
+A_4E_C:defineToggleSwitch("HOOK_HANDLE", 15, 3021, 10, "Mechanical Systems", "Landing Hook Handle")
+A_4E_C:defineToggleSwitch("SPOILER_ARM", 16, 3017, 84, "Mechanical Systems", "Spoiler Arm Switch")
+A_4E_C:defineToggleSwitch("SPEEDBRAKE", 13, 3024, 85, "Mechanical Systems", "Speedbrake Switch")
+A_4E_C:define3PosTumb("SPEEDBRAKE_EMERG", 13, 3035, 128, "Mechanical Systems", "Speedbrake Emergency")
+A_4E_C:defineToggleSwitch("CANOPY_SW", 17, 71, 0, "Mechanical Systems", "Canopy")
+A_4E_C:define3PosTumb("FLAPS", 14, 3015, 132, "Mechanical Systems", "Flaps Lever")
+A_4E_C:definePotentiometer("RUDDER_TRIM", 26, 3085, 82, { -1, 1 }, "Mechanical Systems", "Rudder Trim")
+A_4E_C:define3PosTumb("THROTTLE_CLICK", 20, 3087, 0, "Mechanical Systems", "Throttle Cutoff/Start/Idle")
+A_4E_C:definePushButton("STARTER_BTN", 20, 3013, 100, "Mechanical Systems", "Starter Button")
+A_4E_C:defineToggleSwitch("JATO_ARM", 2, 3158, 133, "Mechanical Systems", "JATO ARM-OFF Switch")
+A_4E_C:defineToggleSwitch("JATO_JETT_SAFE", 2, 3159, 134, "Mechanical Systems", "JATO JETTISON-SAFE Switch")
+
+--Fuel Systems
+A_4E_C:define3PosTumb(
+	"DROP_PRESS_REFUEL",
+	20,
+	3144,
+	101,
+	"Fuel Systems",
+	"Drop Tanks Pressurization and Flight Refuel Switch"
+)
+A_4E_C:define3PosTumb(
+	"EMERG_TRANS_FUEL_DUMP",
+	20,
+	3143,
+	103,
+	"Fuel Systems",
+	"Emergency Transfer and Wing Fuel Dump Switch"
+)
+A_4E_C:defineToggleSwitch("FUEL_CONTROL", 20, 3145, 104, "Fuel Systems", "Fuel Control Switch")
+A_4E_C:defineToggleSwitch("MAN_FUEL_OFF_LV", 20, 3146, 130, "Fuel Systems", "Manual Fuel Shutoff Lever")
+A_4E_C:defineToggleSwitch("MAN_FUEL_OFF_CATCH", 20, 3147, 131, "Fuel Systems", "Manual Fuel Shutoff Catch")
+
+-- OXYGEN and ANTI-G PANEL
+A_4E_C:defineToggleSwitch("OXY_SW", 2, 3138, 125, "Avionics", "Oxygen Switch")
+
+--Avionics
+A_4E_C:definePushButton("ACCEL_RESET", 2, 3111, 139, "Avionics", "Reset Accelerometer")
+A_4E_C:definePushButton("STOPWATCH", 8, 3105, 146, "Clock", "Stopwatch Start/Stop")
+A_4E_C:definePushButton("RADAR_ALT_SW", 19, 3038, 603, "Avionics", "Radar Altimeter Warning Button")
+A_4E_C:defineRotary("RADAR_ALT_INDEX", 19, 3037, 602, "Avionics", "Radar Altimeter Warning Knob")
+A_4E_C:definePushButton("STBY_ATT_INDEX_BTN", 2, 3042, 663, "Avionics", "Standby Attitude Horizon Button")
+A_4E_C:defineRotary("STBY_ATT_INDEX_KNB", 2, 3043, 662, "Avionics", "Standby Attitude Horizon Knob")
+A_4E_C:definePushButton("FUEL_EXT_BTN", 2, 3018, 720, "Avionics", "Show EXT Fuel")
+A_4E_C:definePushButton("MASTER_TEST", 2, 3039, 723, "Avionics", "Master Test")
+A_4E_C:defineRotary("ALT_PRESS_KNB", 2, 3019, 827, "Avionics", "Altimeter Setting")
+A_4E_C:definePushButton("IAS_INDEX_BTN", 2, 3040, 885, "Avionics", "IAS Index Button")
+A_4E_C:definePotentiometer("IAS_INDEX_KNB", 2, 3041, 884, { 0, 1 }, "Avionics", "IAS Index Knob")
+A_4E_C:definePotentiometer("AOA_INDEX_DIM", 2, 3164, 853, { -1, 1 }, "Avionics", "AOA Indexer Dimming Wheel")
+
+--Gunsight
+A_4E_C:defineRotary("GUNSIGHT_BRIGHT", 22, 3030, 895, "Gunsight", "Gunsight Light Control")
+A_4E_C:defineToggleSwitch("GUNSIGHT_DAY_NIGHT", 22, 3029, 891, "Gunsight", "Gunsight Day/Night Switch")
+A_4E_C:definePotentiometer("GUNSIGHT_KNB", 22, 3028, 892, { 0, 1 }, "Gunsight", "Gunsight Elevation Control")
+
+--TACAN
+A_4E_C:defineMultipositionSwitch("TACAN_MODE", 23, 3069, 900, 4, 0.1, "TACAN", "TACAN Mode")
+A_4E_C:defineMultipositionSwitch("TACAN_CHAN_MAJ", 23, 3070, 901, 13, 0.05, "TACAN", "TACAN Channel Major")
+A_4E_C:defineMultipositionSwitch("TACAN_CHAN_MIN", 23, 3071, 902, 10, 0.1, "TACAN", "TACAN Channel Minor")
+A_4E_C:definePotentiometer("TACAN_VOL", 23, 3072, 903, { -1, 1 }, "TACAN", "TACAN Volume")
+
+--Doppler Navigation Computer
+A_4E_C:defineMultipositionSwitch("DOPPLER_SEL", 23, 3045, 170, 5, 0.1, "Doppler Nav", "APN-153 Doppler Radar Mode")
+A_4E_C:definePushButton("DOPPLER_MEM_TEST", 23, 3046, 247, "Doppler Nav", "APN-153 Memory Light Test")
+A_4E_C:defineMultipositionSwitch("NAV_SEL", 23, 3047, 176, 5, 0.1, "Doppler Nav", "ASN-41 Function Selector Switch")
+A_4E_C:defineRotary("PPOS_LAT_KNB", 23, 3051, 177, "Doppler Nav", "ASN-41 Present Position - Latitude Knob")
+A_4E_C:definePushButton("PPOS_LAT_BTN", 23, 3150, 236, "Doppler Nav", "ASN-41 Present Position - Latitude Button")
+A_4E_C:defineRotary("PPOS_LON_KNB", 23, 3052, 183, "Doppler Nav", "ASN-41 Present Position - Longitude Knob")
+A_4E_C:definePushButton("PPOS_LON_BTN", 23, 3151, 237, "Doppler Nav", "ASN-41 Present Position - Longitude Button")
+A_4E_C:defineRotary("DEST_LAT_KNB", 23, 3053, 190, "Doppler Nav", "ASN-41 Destination - Latitude Knob")
+A_4E_C:definePushButton("DEST_LAT_BTN", 23, 3152, 238, "Doppler Nav", "ASN-41 Destination - Latitude Button")
+A_4E_C:defineRotary("DEST_LON_KNB", 23, 3054, 196, "Doppler Nav", "ASN-41 Destination - Longitude Knob")
+A_4E_C:definePushButton("DEST_LON_BTN", 23, 3153, 239, "Doppler Nav", "ASN-41 Destination - Longitude Button")
+A_4E_C:defineRotary("ASN41_MAGVAR_KNB", 23, 3048, 203, "Doppler Nav", "ASN-41 Magnetic Variation Knob")
+A_4E_C:definePushButton("ASN41_MAGVAR_BTN", 23, 3154, 240, "Doppler Nav", "ASN-41 Magnetic Variation Button")
+A_4E_C:defineRotary("ASN41_WINDSPEED_KNB", 23, 3049, 209, "Doppler Nav", "ASN-41 Wind Speed Knob")
+A_4E_C:definePushButton("ASN41_WINDSPEED_BTN", 23, 3155, 241, "Doppler Nav", "ASN-41 Wind Speed Button")
+A_4E_C:defineRotary("ASN41_WINDDIR_KNB", 23, 3050, 213, "Doppler Nav", "ASN-41 Wind Direction Knob")
+A_4E_C:definePushButton("ASN41_WINDDIR_BTN", 23, 3156, 242, "Doppler Nav", "ASN-41 Wind Bearing Button")
+
+--Lights
+A_4E_C:define3PosTumb("LIGHT_EXT_MASTER", 25, 3073, 83, "Lights", "Master Lighting ON/OFF/Momentary")
+A_4E_C:define3PosTumb("LIGHT_EXT_PROBE", 25, 3074, 217, "Lights", "Probe Light")
+A_4E_C:defineToggleSwitch("LIGHT_EXT_TAXI", 25, 3075, 218, "Lights", "Taxi Light")
+A_4E_C:defineToggleSwitch("LIGHT_EXT_ANTICOLL", 25, 3076, 219, "Lights", "Anti-Collision Lights")
+A_4E_C:define3PosTumb("LIGHT_EXT_FUSELAGE", 25, 3077, 220, "Lights", "Fuselage Lights")
+A_4E_C:defineToggleSwitch("LIGHT_EXT_FLASH_MODE", 25, 3078, 221, "Lights", "Lighting Flash/Steady Mode")
+A_4E_C:define3PosTumb("LIGHT_EXT_NAV", 25, 3079, 222, "Lights", "Navigation Lights")
+A_4E_C:define3PosTumb("LIGHT_EXT_TAIL", 25, 3080, 223, "Lights", "Tail Light")
+A_4E_C:definePotentiometer("LIGHT_INT_INSTR", 2, 3082, 106, { 0, 1 }, "Lights", "Instrument Lighting")
+A_4E_C:definePotentiometer("LIGHT_INT_CONSOLE", 2, 3083, 107, { 0, 1 }, "Lights", "Console Lighting")
+A_4E_C:define3PosTumb("LIGHT_INT_BRIGHT", 2, 3084, 108, "Lights", "Console Light Intensity")
+A_4E_C:definePotentiometer("LIGHT_INT_FLOOD_WHT", 2, 3081, 110, { 0, 1 }, "Lights", "White FloodLight Control")
+
+--UHF Radio
+A_4E_C:defineMultipositionSwitch(
+	"ARC51_FREQ_PRE",
+	28,
+	3101,
+	361,
+	20,
+	0.05,
+	"UHF Radio",
+	"ARC-51 UHF Preset Channel Selector"
+)
+A_4E_C:definePotentiometer("ARC51_VOL", 28, 3099, 365, { 0, 1 }, "UHF Radio", "ARC-51 UHF Volume")
+A_4E_C:define3PosTumb("ARC51_XMIT_MODE", 28, 3098, 366, "UHF Radio", "ARC-51 UHF Frequency Mode")
+A_4E_C:defineMultipositionSwitch(
+	"ARC51_FREQ_10MHZ",
+	28,
+	3102,
+	367,
+	18,
+	0.05,
+	"UHF Radio",
+	"ARC-51 UHF Manual Frequency 10 MHz"
+)
+A_4E_C:defineMultipositionSwitch(
+	"ARC51_FREQ_1MHZ",
+	28,
+	3103,
+	368,
+	10,
+	0.1,
+	"UHF Radio",
+	"ARC-51 UHF Manual Frequency 1 MHz"
+)
+A_4E_C:defineMultipositionSwitch(
+	"ARC51_FREQ_50KHZ",
+	28,
+	3104,
+	369,
+	20,
+	0.05,
+	"UHF Radio",
+	"ARC-51 UHF Manual Frequency 50 kHz"
+)
+A_4E_C:defineToggleSwitch("ARC51_SQUELCH", 28, 3100, 370, "UHF Radio", "ARC-51 UHF Squelch Disable")
+A_4E_C:defineMultipositionSwitch("ARC51_MODE", 28, 3097, 372, 4, 0.1, "UHF Radio", "ARC-51 UHF Mode")
+
+--T Handles
+A_4E_C:defineToggleSwitch("EMERG_GEAR_REL", 15, 3036, 1240, "T Handles", "Emergency Gear Release")
+A_4E_C:defineToggleSwitch("EMERG_BOMB_REL", 6, 3027, 1241, "T Handles", "Emergency Bomb Release")
+A_4E_C:defineToggleSwitch("EMERG_GEN_DEPLOY", 3, 3023, 1243, "T Handles", "Emergency Generator Deploy")
+A_4E_C:defineToggleSwitch("EMERG_GEN_BYPASS", 3, 3022, 252, "T Handles", "Emergency Generator Bypass/Normal")
+A_4E_C:defineToggleSwitch("MAN_FLIGHT_CONTROL", 7, 3136, 1242, "T Handles", "Manual Flight Control Override")
+
+--ECM Panel
+A_4E_C:defineToggleSwitch("ECM_AUDIO", 31, 3114, 503, "ECM Panel", "Audio APR/25 - APR/27")
+A_4E_C:defineToggleSwitch("ECM_APR25_PW", 31, 3113, 504, "ECM Panel", "APR/25 On/Off")
+A_4E_C:defineToggleSwitch("ECM_APR27_PW", 31, 3115, 501, "ECM Panel", "APR/27 On/Off")
+A_4E_C:definePushButton("ECM_APR27_TEST", 31, 3116, 507, "ECM Panel", "APR/27 Test")
+A_4E_C:definePushButton("ECM_APR27_LIGHT", 31, 3117, 510, "ECM Panel", "APR/27 Light")
+A_4E_C:definePotentiometer("ECM_PRF_VOL", 31, 3118, 506, { -0.9, 0.9 }, "ECM Panel", "PRF Volume (Inner Knob)")
+A_4E_C:definePotentiometer("ECM_MSL_VOL", 31, 3119, 505, { -0.9, 0.9 }, "ECM Panel", "MSL Volume (Outer Knob)")
+A_4E_C:defineMultipositionSwitch("ECM_SEL", 31, 3120, 502, 4, 0.33, "ECM Panel", "AN/APR-25 Selector Knob")
+
+--AIR CONDITIONING PANEL
+A_4E_C:defineToggleSwitch("CABIN_PRESS", 3, 3133, 224, "Air Condition", "Cabin Pressure Switch")
+A_4E_C:define3PosTumb("WINDSHLD_DEFROST", 3, 3134, 225, "Air Condition", "Windshield Defrost")
+A_4E_C:definePotentiometer("CABIN_TEMP", 3, 3135, 226, { 0, 1 }, "Air Condition", "Cabin Temp Knob")
+
+--EJECTION SEAT
+A_4E_C:defineToggleSwitch("HARNESS_REEL_CONTR", 2, 3148, 24, "Ejection Seat", "Shoulder Harness Inertia Reel Control")
+A_4E_C:defineToggleSwitch("SEC_EJECT_HANDLE", 2, 3149, 25, "Ejection Seat", "Secondary Ejection Handle")
+
+A_4E_C:define3PosTumb("ASN41_LAT_SLEW", 23, 3165, 248, "Doppler Nav", "ASN-41 Destination - Latitude Slew")
+A_4E_C:define3PosTumb("ASN41_LON_SLEW", 23, 3166, 249, "Doppler Nav", "ASN-41 Destination - Longitude Slew")
+
+--Externals
+A_4E_C:defineIntegerFromGetter("EXT_SPEED_BRAKES", function()
+	return math.floor(LoGetAircraftDrawArgumentValue(500) * 65535)
+end, 65535, "External Aircraft Model", "Speed Brakes")
+A_4E_C:defineIntegerFromGetter("EXT_HOOK", function()
+	return math.floor(LoGetAircraftDrawArgumentValue(25) * 65535)
+end, 65535, "External Aircraft Model", "Hook")
+A_4E_C:defineIntegerFromGetter("EXT_POSITION_LIGHT_LEFT", function()
+	if LoGetAircraftDrawArgumentValue(190) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Left Position Light (red)")
+A_4E_C:defineIntegerFromGetter("EXT_POSITION_LIGHT_RIGHT", function()
+	if LoGetAircraftDrawArgumentValue(191) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Right Position Light (green)")
+A_4E_C:defineIntegerFromGetter("EXT_TAIL_LIGHT", function()
+	if LoGetAircraftDrawArgumentValue(192) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Tail Light (white)")
+A_4E_C:defineIntegerFromGetter("EXT_STROBE_TOP", function()
+	if LoGetAircraftDrawArgumentValue(198) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Top Strobe Light (red)")
+A_4E_C:defineIntegerFromGetter("EXT_STROBE_BOTTOM", function()
+	if LoGetAircraftDrawArgumentValue(199) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Bottom Strobe Light (red)")
+A_4E_C:defineIntegerFromGetter("EXT_TAXI_LIGHT", function()
+	if LoGetAircraftDrawArgumentValue(208) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Taxi Light (white)")
+A_4E_C:defineIntegerFromGetter("EXT_WOW_NOSE", function()
+	if LoGetAircraftDrawArgumentValue(1) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Nose Gear")
+A_4E_C:defineIntegerFromGetter("EXT_WOW_RIGHT", function()
+	if LoGetAircraftDrawArgumentValue(4) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Right Gear")
+A_4E_C:defineIntegerFromGetter("EXT_WOW_LEFT", function()
+	if LoGetAircraftDrawArgumentValue(6) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Left Gear")
+
+A_4E_C:defineFloat("AFCS_ROLL", 260, { -1, 1 }, "AFCS", "AFCS Roll Gauge")
+A_4E_C:defineFloat("AFCS_YAW", 261, { -1, 1 }, "AFCS", "AFCS Yaw Gauge")
+A_4E_C:defineFloat("AFCS_PITCH", 262, { -1, 1 }, "AFCS", "AFCS Pitch Gauge")
+A_4E_C:defineToggleSwitch("AFCS_1N2_COVER", 27, 3169, 258, "AFCS", "AFCS 1-N-2 Guard Cover")
+A_4E_C:define3PosTumb("AFCS_1N2", 27, 3170, 259, "AFCS", "AFCS 1-N-2 Guard")
+A_4E_C:defineMultipositionSwitch("MCL_CHAN_SEL", 37, 3167, 250, 20, 0.05, "MCL", "MCL Channel Selector")
+A_4E_C:define3PosTumb("MCL_PWR", 37, 3168, 253, "MCL", "MCL Power")
+A_4E_C:define3PosTumb("SEAT_ADJ", 45, 3174, 251, "Mechanical Systems", "Seat Adjustment")
+A_4E_C:define3PosTumb("TACAN_ANT_CONT", 23, 3171, 254, "TACAN", "TACAN Antenna Control")
+A_4E_C:defineToggleSwitch("NAV_DEAD", 23, 3173, 255, "Doppler Nav", "Navigation Dead Reckoning/Doppler")
+A_4E_C:defineToggleSwitch("FUEL_TRANS", 20, 3175, 256, "Fuel Systems", "Fuel Transfer Bypass/Normal")
+A_4E_C:defineToggleSwitch("RAIN_REMOVE", 2, 3172, 257, "Avionics", "Rain Removal")
+
+--COMPASS CONTROLLER
+--A_4E_C:defineRotary("COMP_LAT_KNB", XX, 3142, 509, "Compass", "Compass Latitude Knob")
+--A_4E_C:define3PosTumb("COMP_SET_HDG", XX, 3139, 511, "Compass", "Compass Heading Set Knob")
+--A_4E_C:defineToggleSwitch("COMP_FREE_SLAVE_SW", XX, 3141, 512, "Compass", "Compass Free/Slaved Mode Switch")
+--A_4E_C:definePushButton("COMP_SYNC", XX, 3140, 513, "Compass", "Compass Push to Sync")
+
+return A_4E_C

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/P-51D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/P-51D.lua
@@ -1,0 +1,486 @@
+module("P-51D", package.seeall)
+
+local Module = require("Module")
+
+--- @class P-51D : Module
+local P_51D = Module:new("P-51D", 0x5000, { "P-51D", "TF-51D", "P-51D-30-NA" })
+
+P_51D:defineToggleSwitch("GEN", 14, 3003, 102, "Right Switch Panel", "Generator")
+P_51D:defineToggleSwitch("BAT", 14, 3001, 103, "Right Switch Panel", "Battery")
+P_51D:defineToggleSwitch("GUN_HEAT", 14, 3019, 104, "Right Switch Panel", "Gun Heating")
+P_51D:defineToggleSwitch("PITOT", 14, 3005, 105, "Right Switch Panel", "Pitot Heating")
+P_51D:define3PosTumb("WING_LTS", 14, 3008, 106, "Right Switch Panel", "Wing Position Lights Bright/Off/Dim")
+P_51D:define3PosTumb("TAIL_LTS", 14, 3009, 107, "Right Switch Panel", "Tail Position Lights Bright/Off/Dim")
+P_51D:define3PosTumb("RED_REC_LT", 14, 3021, 108, "Right Switch Panel", "Red Recognition Light Key/Off/Steady")
+P_51D:define3PosTumb("GRN_REC_LT", 14, 3022, 109, "Right Switch Panel", "Green Recognition Light Key/Off/Steady")
+P_51D:define3PosTumb("AMBR_REC_LT", 14, 3023, 110, "Right Switch Panel", "Amber Recognition Light Key/Off/Steady")
+P_51D:definePushButton("REC_LTS_KEY", 14, 3024, 111, "Right Switch Panel", "Recognition Lights Key")
+P_51D:definePushButton("CIRC_PRO_RST", 14, 3025, 112, "Right Switch Panel", "Circuit Protectors Reset")
+P_51D:definePotentiometer("RT_FLRES_LT", 14, 3007, 100, { 0, 1 }, "Right Switch Panel", "Right Fluorescent Light")
+P_51D:defineToggleSwitch("GUNSIGHT_ON_OFF", 1, 3004, 41, "K14 Gunsight", "Gunsight On/Off")
+P_51D:defineToggleSwitch("RET_MASK_LVR", 1, 3006, 39, "K14 Gunsight", "Fixed Reticle Mask Lever")
+P_51D:defineTumb(
+	"GUNSIGHT_FIXED_GYRO",
+	1,
+	3016,
+	40,
+	0.1,
+	{ 0, 0.2 },
+	nil,
+	false,
+	"K14 Gunsight",
+	"Fixed Fixed-Gyro Gyro"
+)
+P_51D:definePotentiometer("GUNSIGHT_BRT", 1, 3005, 42, { 0, 1 }, "K14 Gunsight", "Gun Sight Brightness")
+P_51D:definePotentiometer("WING_SPAN_SEL", 1, 3001, 35, { 0, 1 }, "K14 Gunsight", "Wing Span Selector")
+P_51D:defineToggleSwitch("HYD_REL", 3, 3001, 79, "Hydraulic System", "Hydraulic Release Knob")
+P_51D:defineTumb("RKT_REL_MODE", 4, 3007, 73, 0.1, { 0, 0.2 }, nil, false, "Weapon Control", "Rockets Release Mode")
+P_51D:defineToggleSwitch("RKT_DEL_SWITCH", 4, 3008, 74, "Weapon Control", "Rockets Delay Switch")
+P_51D:defineToggleSwitch("LFT_PYLOD_SLVO", 4, 3003, 132, "Weapon Control", "Left Payload Salvo")
+P_51D:defineToggleSwitch("RT_PYLOD_SLVO", 4, 3004, 133, "Weapon Control", "Right Payload Salvo")
+P_51D:defineToggleSwitch("COOLANT_CONTROL_COVER", 5, 3003, 168, "Engine System", "Coolant Control Cover")
+P_51D:defineTumb("COOLANT_CONTROL", 5, 3001, 87, 0.1, { 0, 0.3 }, nil, false, "Engine System", "Coolant Control")
+P_51D:defineToggleSwitch("OIL_CONTROL_COVER", 5, 3004, 169, "Engine System", "Oil Control Cover")
+P_51D:defineTumb("OIL_CONTROL", 5, 3002, 88, 0.1, { 0, 0.3 }, nil, false, "Engine System", "Oil Control")
+P_51D:definePotentiometer("CARB_COLD_AIR", 5, 3007, 134, { 0, 1 }, "Engine System", "Carburetor Cold Air Control")
+P_51D:definePotentiometer("CARB_WARM_AIR", 5, 3027, 135, { 0, 1 }, "Engine System", "Carburetor Warm Air Control")
+P_51D:defineTumb("MIXTURE_CONTROL", 5, 3019, 47, 0.1, { 0, 0.2 }, nil, false, "Engine System", "Mixture Control")
+P_51D:definePotentiometer("THROTTLE", 5, 3021, 43, { 0.0, 0.9 }, "Engine System", "Throttle")
+P_51D:definePotentiometer("PROPELLER_RPM", 5, 3022, 46, { 0, 1 }, "Engine System", "Propeller RPM")
+P_51D:definePotentiometer("LOCK_THROTTLE", 5, 3012, 48, { 0, 1 }, "Engine System", "Lock Throttle")
+P_51D:definePotentiometer("LOCK_PROPELLER_MIXTURE", 5, 3014, 49, { 0, 1 }, "Engine System", "Lock Propeller & Mixture")
+P_51D:definePushButton("MICROPHONE_ON", 6, 3001, 44, "Cockpit Mechanical", "Microphone On")
+P_51D:defineToggleSwitch("ARM_REST", 6, 3009, 200, "Cockpit Mechanical", "Arm rest")
+P_51D:definePotentiometer("CANOPY_HAND_CRANK", 6, 3002, 147, { -6, 6 }, "Cockpit Mechanical", "Canopy Hand Crank")
+P_51D:defineToggleSwitch(
+	"CANOPY_EMERGENCY_RELEASE_HANDLE",
+	6,
+	3003,
+	149,
+	"Cockpit Mechanical",
+	"Canopy Emergency Release Handle"
+)
+P_51D:defineToggleSwitch("OXYGEN_AUTO_MIX", 7, 3003, 131, "Oxygen System", "Auto-Mix On-Off")
+P_51D:defineToggleSwitch("OXYGEN_BYPASS", 7, 3001, 130, "Oxygen System", "Oxygen Emergency By-pass")
+P_51D:defineFloat("PANEL_LIGHTS", 165, { 0, 1 }, "Light System", "Panel Background Lighting (green)")
+P_51D:defineMultipositionSwitch("FUEL_SELECTOR_VALVE", 9, 3001, 85, 5, 0.1, "Fuel System", "Fuel Selector Valve")
+P_51D:defineToggleSwitch("FUEL_SHUT_OFF_VALVE", 9, 3005, 86, "Fuel System", "Fuel Shut-Off Valve")
+P_51D:definePotentiometer("LEFT_FLUORESCENT_LIGHT", 10, 3002, 90, { 0, 1 }, "Light System", "Left Fluorescent Light")
+P_51D:defineToggleSwitch("LANDING_LIGHT", 10, 3003, 89, "Light System", "Landing Light On/Off")
+P_51D:defineIndicatorLight("LANDING_GEAR_GREEN", 80, "Light System", "Landing Gear Green Light (green)")
+P_51D:defineIndicatorLight("LANDING_GEAR_RED", 82, "Light System", "Landing Gear Red Light (red)")
+P_51D:definePotentiometer("DEFROSTER", 11, 3001, 157, { 0, 1 }, "Environment System", "Defroster")
+P_51D:definePotentiometer("COLD_AIR", 11, 3002, 158, { 0, 1 }, "Environment System", "Cold Air")
+P_51D:definePotentiometer("HOT_AIR", 11, 3003, 159, { 0, 1 }, "Environment System", "Hot Air")
+P_51D:definePushButton("SAFE_LND_GEAR_LT_TEST", 12, 3018, 81, "Control System", "Safe Landing Gear Light Test")
+P_51D:definePushButton("UNSAFE_LND_GEAR_LT_TEST", 12, 3007, 83, "Control System", "Unsafe Landing Gear Light Test")
+P_51D:definePushButton("PARK_BRAKE_HANDLE", 12, 3005, 84, "Control System", "Parking Brake Handle")
+P_51D:defineRotary("AILERON_TRIM", 12, 3008, 91, "Control System", "Aileron Trim")
+P_51D:defineRotary("ELEVATOR_TRIM", 12, 3009, 92, "Control System", "Elevator Trim")
+P_51D:defineRotary("RUDDER_TRIM", 12, 3010, 93, "Control System", "Rudder Trim")
+P_51D:definePotentiometer("FLAPS_CONTROL_HANDLE", 12, 3001, 94, { 0, 1 }, "Control System", "Flaps Control Handle")
+P_51D:defineToggleSwitch("LANDING_GEAR_CONTR0L_HANDLE", 12, 3003, 150, "Control System", "Landing Gear Control Handle")
+P_51D:definePushButton("LOCK_STICK_FRWD_NEUT", 12, 3015, 173, "Control System", "Lock Stick Forward/Neutral")
+P_51D:definePotentiometer("COCKPIT_LIGHTS", 13, 3001, 71, { 0, 1 }, "Front Switch Box", "Cockpit Lights")
+P_51D:defineTumb(
+	"IGNITION",
+	13,
+	3005,
+	66,
+	0.1,
+	{ 0.0, 0.3 },
+	nil,
+	false,
+	"Front Switch Box",
+	"Ignition Off/Right/Left/Both"
+)
+P_51D:define3PosTumb("GUN_CONTROL", 13, 3007, 67, "Front Switch Box", "Gun/Camera Control")
+P_51D:definePushButton(
+	"SILENCE_GEAR_HORN",
+	13,
+	3008,
+	72,
+	"Front Switch Box",
+	"Silence Landing Gear Warning Horn Cut Off"
+)
+P_51D:define3PosTumb("LEFT_BOMB_ARM_CHEM", 13, 3013, 69, "Front Switch Box", "Left Bomb Arm/Chemical Release")
+P_51D:define3PosTumb("RIGHT_BOMB_ARM_CHEM", 13, 3014, 70, "Front Switch Box", "Right Bomb Arm/Chemical Release")
+P_51D:defineTumb(
+	"ROCKETS_BOMBS_MODES",
+	13,
+	3015,
+	68,
+	0.1,
+	{ 0, 0.3 },
+	nil,
+	false,
+	"Front Switch Box",
+	"Rockets/Bombs Modes"
+)
+P_51D:defineToggleSwitch("SUPERCHARGER_SWITCH_COVER", 15, 3002, 58, "Engine Control Panel", "Supercharger Switch Cover")
+P_51D:defineTumb(
+	"SUPERCHARGER_AUTO_LOW_HIGH",
+	15,
+	3001,
+	57,
+	0.1,
+	{ 0.0, 0.2 },
+	nil,
+	false,
+	"Engine Control Panel",
+	"Supercharger Auto/Low/High"
+)
+P_51D:definePushButton("HIGH_BLOWER_TEST_LAMP", 15, 3004, 60, "Engine Control Panel", "High Blower Lamp Test")
+P_51D:defineIndicatorLight("HIGH_BLOWER_LAMP", 59, "Engine Control Panel", "High Blower Lamp (yellow)")
+P_51D:defineToggleSwitch("FUEL_BOOSTER", 15, 3005, 61, "Engine Control Panel", "Fuel Booster On/Off")
+P_51D:definePushButton("OIL_DILUTE", 15, 3013, 62, "Engine Control Panel", "Oil Dilute Activate")
+P_51D:definePushButton("STARTER", 15, 3008, 63, "Engine Control Panel", "Starter Activate")
+P_51D:defineToggleSwitch("STARTER_COVER", 15, 3009, 64, "Engine Control Panel", "Starter Switch Cover")
+P_51D:definePushButton("PRIMER", 15, 3011, 65, "Engine Control Panel", "Primer Activate")
+P_51D:defineFloat("AIRSPEED_NEEDLE", 11, { 0, 0.7 }, "Airspeed Indicator", "Airspeed Needle")
+P_51D:defineRotary("SET_PRESSURE", 17, 3001, 26, "Altimeter", "Set Pressure")
+P_51D:defineFloat("ALTIMETER_PRESSURE", 97, { 0, 1 }, "Altimeter", "Altimeter Pressure")
+P_51D:defineFloat("ALTIMETER_100_FOOT", 25, { 0, 1 }, "Altimeter", "Altimeter 100 Foot")
+P_51D:defineFloat("ALTIMETER_1000_FOOT", 24, { 0, 1 }, "Altimeter", "Altimeter 1000 Foot")
+P_51D:defineFloat("ALTIMETER_10000_FOOT", 96, { 0, 1 }, "Altimeter", "Altimeter 10000 Foot")
+P_51D:defineFloat("VARIOMETER_VVI", 29, { -0.6, 0.6 }, "Variometer", "Variometer-VVI")
+P_51D:defineFloat("AHORIZON_BANK", 14, { 1, -1 }, "Artificial Horizon", "Artificial Horizon - Bank")
+P_51D:defineFloat("AHORIZON_PITCH", 15, { 1, -1 }, "Artificial Horizon", "Artificial Horizon - Pitch")
+P_51D:defineFloat("AHORIZON_PITCH_SHIFT", 16, { -1, 1 }, "Artificial Horizon", "Artificial Horizon - Pitch Shift")
+P_51D:defineFloat("AHORIZON_CAGED", 20, { 0, 1 }, "Artificial Horizon", "Artificial Horizon - Caged")
+P_51D:defineRotary("PITCH_ADJUST", 19, 3002, 17, "Artificial Horizon", "Pitch Adjustment")
+P_51D:definePushButton("CAGE_BUTTON", 19, 3001, 19, "Artificial Horizon", "Artificial Horizon Cage")
+P_51D:definePotentiometer(
+	"CAGE_ROTARY",
+	19,
+	3003,
+	18,
+	{ 0, 0.14 },
+	"Artificial Horizon",
+	"Artificial Horizon Cage Rotary"
+)
+P_51D:defineFloat("DIRECTIONAL_GYRO", 12, { 0, 1 }, "Directional Gyro", "Directional Gyro Heading")
+P_51D:definePushButton("HDG_CAGE_BUTTON", 20, 3003, 179, "Directional Gyro", "Directional Gyro Cage")
+P_51D:defineRotary("HDG_CAGE_ROTARY", 20, 3001, 13, "Directional Gyro", "Directional Gyro Heading Set")
+P_51D:defineFloat("TURN_INDICATOR", 27, { -1, 1 }, "Turn Indicator", "Turn Indicator")
+P_51D:defineFixedStepTumb(
+	"CLOCK_ADJUST_BUTTON",
+	22,
+	3001,
+	8,
+	1,
+	{ 0, 1 },
+	{ -1, 1 },
+	nil,
+	"Clock",
+	"Clock Adjust Button"
+)
+P_51D:defineRotary("CLOCK_ADJUST", 22, 3002, 7, "Clock", "Clock Adjust")
+P_51D:defineFloat("CLOCK_HOURS", 4, { 0, 1.0 }, "Clock", "Clock Hours")
+P_51D:defineFloat("CLOCK_MINUTES", 5, { 0, 1.0 }, "Clock", "Clock Minutes")
+P_51D:defineFloat("CLOCK_SECONDS", 6, { 0, 1.0 }, "Clock", "Clock Seconds")
+P_51D:defineRotary("REMOTE_COMPASS_SET", 23, 3001, 3, "Remote Compass", "Course Set")
+P_51D:defineFloat("REMOTE_COMPASS_HDG", 1, { 0, 1 }, "Remote Compass", "Remote Compass Heading")
+P_51D:defineFloat("REMOTE_COMPASS_CRS", 2, { 0, 1 }, "Remote Compass", "Remote Compass Course")
+P_51D:definePushButton("VHF_RADIO_ON_OFF", 24, 3001, 117, "VHF Radio", "VHF Radio On/Off")
+P_51D:definePushButton("VHF_RADIO_CHAN_A", 24, 3002, 118, "VHF Radio", "VHF Radio Channel A")
+P_51D:definePushButton("VHF_RADIO_CHAN_B", 24, 3003, 119, "VHF Radio", "VHF Radio Channel B")
+P_51D:definePushButton("VHF_RADIO_CHAN_C", 24, 3004, 120, "VHF Radio", "VHF Radio Channel C")
+P_51D:definePushButton("VHF_RADIO_CHAN_D", 24, 3005, 121, "VHF Radio", "VHF Radio Channel D")
+P_51D:defineToggleSwitch("RADIO_LIGHTS_DIMMER", 24, 3006, 127, "VHF Radio", "Radio Lights Dimmer")
+P_51D:definePotentiometer("RADIO_VOLUME", 24, 3015, 116, { 0, 1 }, "VHF Radio", "Radio Audio Volume ")
+P_51D:defineToggleSwitch("VHF_LOCKING_LEVER", 24, 3017, 129, "VHF Radio", "Switch Locking Lever")
+P_51D:defineFixedStepTumb("RADIO_MODE2", 24, 3021, 128, 1, { -1, 1 }, { -1, 1 }, nil, "VHF Radio", "Radio Mode2")
+P_51D:defineFixedStepTumb("RADIO_MODE3", 24, 3008, 128, 1, { -1, 1 }, { -1, 1 }, nil, "VHF Radio", "Radio Mode3")
+P_51D:defineIndicatorLight("VHF_RADIO_A_LIGHT", 122, "VHF Radio", "VHF Radio A Light (green)")
+P_51D:defineIndicatorLight("VHF_RADIO_B_LIGHT", 123, "VHF Radio", "VHF Radio B Light (green)")
+P_51D:defineIndicatorLight("VHF_RADIO_C_LIGHT", 124, "VHF Radio", "VHF Radio C Light (green)")
+P_51D:defineIndicatorLight("VHF_RADIO_D_LIGHT", 125, "VHF Radio", "VHF Radio D Light (green)")
+P_51D:defineIndicatorLight("VHF_RADIO_TX_LIGHT", 126, "VHF Radio", "VHF Radio TX Light (white)")
+P_51D:defineToggleSwitch("WARNING_RADAR_POWER", 25, 3001, 114, "Tail Warning Radar", "Tail Warning Radar Power")
+P_51D:definePushButton("WARNING_RADAR_TEST", 25, 3003, 115, "Tail Warning Radar", "Tail Warning Radar Test")
+P_51D:definePotentiometer(
+	"WARNING_RADAR_LIGHT",
+	25,
+	3004,
+	113,
+	{ 0, 1 },
+	"Tail Warning Radar",
+	"Tail Warning Radar Light Control"
+)
+P_51D:defineIndicatorLight("RADAR_WARNING_LIGHT", 161, "Tail Warning Radar", "Radar Warning Light (yellow)")
+P_51D:definePotentiometer("DETROLA_FREQUENCY", 26, 3004, 137, { 0, 1 }, "Detrola", "Detrola Frequency Selector")
+P_51D:definePotentiometer("DETROLA_VOLUME", 26, 3001, 138, { 0, 1 }, "Detrola", "Detrola Volume")
+P_51D:defineToggleSwitch("OFF_POWER", 27, 3001, 140, "IFF", "IFF Power On/Off")
+P_51D:defineToggleSwitch("IFF_DISTRESS", 27, 3005, 143, "IFF", "IFF Distress Signal On/Off")
+P_51D:defineToggleSwitch("IFF_DET_CIRCUIT", 27, 3004, 142, "IFF", "IFF Detonator Circuit On/Off")
+P_51D:definePushButton("IFF_DET_LEFT", 27, 3007, 145, "IFF", "IFF Detonator Left")
+P_51D:definePushButton("IFF_DET_RIGHT", 27, 3008, 146, "IFF", "IFF Detonator Right")
+P_51D:define3PosTumb("IFF_TIME_OFF_ON", 27, 3003, 141, "IFF", "IFF Time/Off/On")
+P_51D:defineTumb("IFF_CODE", 27, 3016, 139, 0.1, { 0, 0.5 }, nil, false, "IFF", "IFF Code 1-6")
+P_51D:defineToggleSwitch("HOMING_ADAPTER_POWER", 28, 3004, 153, "Homing Adapter", "Homing Adapter CW/MCW Switch")
+P_51D:definePushButton("HOMING_ADAPTER_CB", 28, 3003, 154, "Homing Adapter", "Homing Adapter Circuit Breaker")
+P_51D:defineTumb(
+	"HOMING_ADAPTER_MODE",
+	28,
+	3001,
+	152,
+	0.1,
+	{ 0, 0.2 },
+	nil,
+	false,
+	"Homing Adapter",
+	"Homing Adapter Mode Switch"
+)
+P_51D:defineFloat("ACCELEROMETER_MAIN", 175, { 0, 1 }, "Accelerometer", "Accelerometer Main")
+P_51D:defineFloat("ACCELEROMETER_MIN", 177, { 0, 1 }, "Accelerometer", "Accelerometer Min")
+P_51D:defineFloat("ACCELEROMETER_MAX", 178, { 0, 1 }, "Accelerometer", "Accelerometer Max")
+P_51D:definePushButton("ACCELEROMETER_RST", 30, 3001, 176, "Accelerometer", "G-meter Reset")
+P_51D:defineFloat("ENGINE_RPM", 23, { 0, 1 }, "Engine System", "Engine RPM")
+P_51D:defineFloat("FUEL_PRESSURE", 32, { 0, 1 }, "Fuel System", "Fuel Pressure")
+P_51D:defineFloat("HYDRAULIC_PRESSURE", 78, { 0, 1 }, "Hydraulic System", "Hydraulic Pressure")
+P_51D:defineFloat("MANIFOLD_PRESSURE", 10, { 0, 1 }, "Engine System", "Manifold Pressure")
+P_51D:defineFloat("ROCKET_COUNTER", 77, { 0, 1 }, "Weapon System", "Rocket Counter")
+P_51D:defineFloat("VACUUM_SUCTION", 9, { 0, 1 }, "Engine System", "Vacuum System")
+P_51D:defineFloat("CARB_TEMP", 21, { -0, 1 }, "Engine System", "Carburetor Temperature")
+P_51D:defineFloat("COOLANT_TEMP", 22, { 0, 1 }, "Engine System", "Coolant Temperature")
+P_51D:defineFloat("OIL_TEMP", 30, { 0, 1.0 }, "Engine System", "Oil Temperature")
+P_51D:defineFloat("OIL_PRES", 31, { 0, 1.0 }, "Engine System", "Oil Pressure")
+P_51D:defineFloat("AMMETER", 101, { 0, 1 }, "Electric System", "Ammeter")
+P_51D:defineFloat("WINDSHIELD_OIL", 147, { 0, 1 }, "Environment System", "Windshield Oil")
+P_51D:defineFloat("OXYGEN_PRES", 34, { 0, 1 }, "Oxygen System", "Oxygen Pressure")
+P_51D:defineFloat("OXYGEN_FLOW", 33, { 0, 1 }, "Oxygen System", "Oxygen Flow Blinker")
+P_51D:defineFloat("SLIPBALL", 28, { -1, 1 }, "Turn Indicator", "Slipball")
+P_51D:defineFloat("FUEL_TANK_LEFT", 155, { 0, 1 }, "Fuel System", "Fuel Tank Left")
+P_51D:defineFloat("FUEL_TANK_RIGHT", 156, { 0, 1 }, "Fuel System", "Fuel Tank Right")
+P_51D:defineFloat("FUEL_TANK_FUSELAGE", 160, { 0, 1 }, "Fuel System", "Fuel Tank Fuselage")
+
+--Externals
+P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_LEFT", function()
+	if LoGetAircraftDrawArgumentValue(190) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Left Position Light (red)")
+P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_RIGHT", function()
+	if LoGetAircraftDrawArgumentValue(191) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Right Position Light (green)")
+P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_TAIL", function()
+	if LoGetAircraftDrawArgumentValue(192) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Tail Position Light (white)")
+P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_RD", function()
+	if LoGetAircraftDrawArgumentValue(200) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Red Recognition Light (red)")
+P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_GN", function()
+	if LoGetAircraftDrawArgumentValue(201) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Green Recognition Light (green)")
+P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_YE", function()
+	if LoGetAircraftDrawArgumentValue(202) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Amber Recognition Light (yellow)")
+
+--[[--Gauge Values--]]
+--
+local function getAirspeed()
+	local returnValue = (GetDevice(0):get_argument_value(11)) * 1000
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("AIRSPEED_MPH_VALUE", getAirspeed, 65000, "Gauge Values", "Airspeed MPH")
+
+local function getAltitude()
+	local returnValue = (GetDevice(0):get_argument_value(96)) * 100000
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("ALTIMETER_VALUE", getAltitude, 65000, "Gauge Values", "Altimeter")
+
+local function getEngineRPM()
+	local returnValue = (GetDevice(0):get_argument_value(23)) * 4500
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("ENGINE_RPM_VALUE", getEngineRPM, 65000, "Gauge Values", "Engine RPM Value")
+
+local function getGyro()
+	local returnValue = (GetDevice(0):get_argument_value(12)) * 360
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("DIRECTIONAL_GYRO_VALUE", getGyro, 65000, "Gauge Values", "Directional Gyro")
+
+local function getHDG()
+	local returnValue = (GetDevice(0):get_argument_value(1)) * 360
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("HEADING_VALUE", getHDG, 65000, "Gauge Values", "Remote Compass Heading")
+
+local function getCRS()
+	local returnValue = (GetDevice(0):get_argument_value(2)) * 360
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("COURSE_VALUE", getCRS, 65000, "Gauge Values", "Remote Compass Course")
+
+local function getFuelPres()
+	local returnValue = (GetDevice(0):get_argument_value(32)) * 25
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("FUEL_PRESSURE_VALUE", getFuelPres, 65000, "Gauge Values", "Fuel Pressure")
+
+local function getHydPres()
+	local returnValue = (GetDevice(0):get_argument_value(78)) * 2000
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("HYDRAULIC_PRESSURE_VALUE", getHydPres, 65000, "Gauge Values", "Hydraulic Pressure")
+
+local function getManifoldPres()
+	local returnValue = (GetDevice(0):get_argument_value(10)) * 65 + 10
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("MANIFOLD_PRESSURE_VALUE", getManifoldPres, 65000, "Gauge Values", "Manifold Pressure")
+
+local function getVacuum()
+	local returnValue = (GetDevice(0):get_argument_value(9)) * 100
+	return returnValue
+end
+P_51D:defineIntegerFromGetter(
+	"VACUUM_SUCTION_VALUE",
+	getVacuum,
+	65000,
+	"Gauge Values",
+	"Vacuum Suction read as X.X or XX.X"
+)
+
+local function getOilTemp()
+	local returnValue = (GetDevice(0):get_argument_value(30)) * 100
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("OIL_TEMPERATURE_VALUE", getOilTemp, 65000, "Gauge Values", "Oil Temperature")
+
+local function getOilPres()
+	local returnValue = (GetDevice(0):get_argument_value(31)) * 200
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("OIL_PRESSURE_VALUE", getOilPres, 65000, "Gauge Values", "Oil Pressure")
+
+local function getAmps()
+	local returnValue = (GetDevice(0):get_argument_value(101)) * 150
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("AMMETER_VALUE", getAmps, 65000, "Gauge Values", "Ammeter")
+
+local function getOxygen()
+	local returnValue = (GetDevice(0):get_argument_value(34)) * 500
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("OXYGEN_PRESSURE_VALUE", getOxygen, 65000, "Gauge Values", "Oxygen Pressure")
+
+local function getLeftFuel()
+	local returnValue = (GetDevice(0):get_argument_value(155)) * 92
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("LEFT_FUEL_TANK_VALUE", getLeftFuel, 65000, "Gauge Values", "Left Fuel Tank Gallons")
+
+local function getRightFuel()
+	local returnValue = (GetDevice(0):get_argument_value(156)) * 92
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("RIGHT_FUEL_TANK_VALUE", getRightFuel, 65000, "Gauge Values", "Right Fuel Tank Gallons")
+
+local function getFuseFuel()
+	local returnValue = (GetDevice(0):get_argument_value(160)) * 85
+	return returnValue
+end
+P_51D:defineIntegerFromGetter(
+	"FUSELAGE_FUEL_TANK_VALUE",
+	getFuseFuel,
+	65000,
+	"Gauge Values",
+	"Fuselage Fuel Tank Gallons"
+)
+
+local function getBaro()
+	local returnValue = (GetDevice(0):get_argument_value(97)) * 290 + 2810
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("BAROMETRIC_PRESSURE_VALUE", getBaro, 65000, "Gauge Values", "Barometric Pressure")
+
+local function getAccel()
+	local returnValue = (GetDevice(0):get_argument_value(175)) * 17 - 5
+	return returnValue
+end
+P_51D:defineIntegerFromGetter("ACCELEROMETER_VALUE", getAccel, 65000, "Gauge Values", "Accelerometer")
+
+P_51D:defineIndicatorLight("WINDSHIELD_OIL_L", 412, "Damage", "Windshield Oil Splashes (black)")
+P_51D:defineFloat("WINDSHIELD_CRACKS", 413, { 0, 1 }, "Damage", "Windshield Crack Holes")
+
+P_51D:defineIntegerFromGetter("EXT_WOW_TAIL", function()
+	if LoGetAircraftDrawArgumentValue(1) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Tail Gear")
+
+P_51D:defineIntegerFromGetter("EXT_WOW_RIGHT", function()
+	if LoGetAircraftDrawArgumentValue(4) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Right Gear")
+
+P_51D:defineIntegerFromGetter("EXT_WOW_LEFT", function()
+	if LoGetAircraftDrawArgumentValue(6) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Weight ON Wheels Left Gear")
+
+P_51D:defineIntegerFromGetter("EXT_LANDING_LIGHT", function()
+	if LoGetAircraftDrawArgumentValue(208) > 0 then
+		return 1
+	else
+		return 0
+	end
+end, 1, "External Aircraft Model", "Landing Light (white)")
+
+P_51D:defineFloat("CANOPY_POS", 162, { 0, 1 }, "Cockpit Mechanical", "Canopy Position")
+P_51D:defineRadioWheel(
+	"RKT_COUNT_CON",
+	4,
+	3009,
+	3010,
+	{ -1 / 11, 1 / 11 },
+	75,
+	1 / 11,
+	{ 0, 1.0 },
+	nil,
+	"Weapon Control",
+	"Rockets Counter Control"
+)
+P_51D:defineFloat("AILERON_TRIM_G", 170, { -1, 1 }, "Control System", "Aileron Trim Gauge")
+P_51D:defineFloat("RUDDER_TRIM_G", 172, { -1, 1 }, "Control System", "Rudder Trim Gauge")
+P_51D:defineFloat("ELEVATOR_TRIM_G", 171, { -1, 1 }, "Control System", "Elevator Trim Gauge")
+P_51D:defineFloat("CONTR_LOCK_BRACK", 174, { 0, 1 }, "Control System", "Control Lock Bracket")
+P_51D:defineFloat("INT_L_LIGHTS", 185, { 0, 1 }, "Light System", "Internal Lighting Left (white)")
+P_51D:defineFloat("INT_R_LIGHTS", 186, { 0, 1 }, "Light System", "Internal Lighting Right (white)")
+
+return P_51D

--- a/Scripts/DCS-BIOS/lib/modules/documentation/ActionArgument.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/ActionArgument.lua
@@ -1,0 +1,9 @@
+module("ActionArgument", package.seeall)
+
+--- @enum ActionArgument
+local ActionArgument = {
+	toggle = "TOGGLE",
+	toggle_xy = "TOGGLE_XY",
+}
+
+return ActionArgument

--- a/Scripts/DCS-BIOS/lib/modules/documentation/ActionInput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/ActionInput.lua
@@ -1,0 +1,26 @@
+module("ActionInput", package.seeall)
+
+local InputType = require("InputType")
+
+--- @class ActionInput: Input
+--- @field argument ActionArgument
+local ActionInput = {}
+
+--- TODO
+--- @param argument ActionArgument
+--- @param description string
+--- @return ActionInput
+function ActionInput:new(argument, description)
+	--- @type ActionInput
+	local o = {
+		interface = InputType.action,
+		argument = argument,
+		description = description,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return ActionInput

--- a/Scripts/DCS-BIOS/lib/modules/documentation/ApiVariant.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/ApiVariant.lua
@@ -1,0 +1,9 @@
+module("ApiVariant", package.seeall)
+
+--- @enum ApiVariant
+local ApiVariant = {
+	momentary_last_position = "momentary_last_position",
+	multiturn = "multiturn",
+}
+
+return ApiVariant

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Category.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Category.lua
@@ -1,0 +1,23 @@
+module("Category", package.seeall)
+
+--- @class Category: { [string]: Control }
+local Category = {}
+
+--- TODO
+--- @return Category
+function Category:new()
+	--- @type Category
+	local o = {}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+--- Adds a new control
+--- @param control Control
+function Category:addControl(control)
+	self[control.identifier] = control
+end
+
+return Category

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Control.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Control.lua
@@ -1,0 +1,54 @@
+module("Control", package.seeall)
+
+--- @class Control
+--- @field category string the category the control is in
+--- @field control_type ControlType the type of the control
+--- @field identifier string the identifier of the control
+--- @field description string
+--- @field inputs Input[] any inputs the control supports
+--- @field outputs Output[] any outputs the control supports
+--- @field momentary_positions MomentaryPositions? TODO
+--- @field physical_variant PhysicalVariant? TODO
+--- @field api_variant ApiVariant? TODO
+local Control = {}
+
+--- TODO
+--- @param category string the category the control is in
+--- @param controlType ControlType the type of the control
+--- @param identifier string the identifier of the control
+--- @param inputs Input[] any inputs the control supports
+--- @param outputs Output[] any outputs the control supports
+--- @param momentaryPositions MomentaryPositions? TODO
+--- @param physicalVariant PhysicalVariant? TODO
+--- @param apiVariant ApiVariant? TODO
+--- @return Control
+function Control:new(
+	category,
+	controlType,
+	identifier,
+	description,
+	inputs,
+	outputs,
+	momentaryPositions,
+	physicalVariant,
+	apiVariant
+)
+	--- @type Control
+	local o = {
+		category = category,
+		control_type = controlType,
+		identifier = identifier,
+		description = description,
+		inputs = inputs,
+		outputs = outputs,
+		momentary_positions = momentaryPositions,
+		physical_variant = physicalVariant,
+		api_variant = apiVariant,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return Control

--- a/Scripts/DCS-BIOS/lib/modules/documentation/ControlType.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/ControlType.lua
@@ -1,0 +1,26 @@
+module("ControlType", package.seeall)
+
+--- @enum ControlType
+local ControlType = {
+	two_pos_two_command_switch_open_close = "2Pos_2Command_Switch_OpenClose",
+	three_pos_two_command_switch_open_close = "3Pos_2Command_Switch_OpenClose",
+	action = "action",
+	analog_dial = "analog_dial",
+	analog_gauge = "analog_gauge",
+	discrete_dial = "discrete_dial",
+	display = "display",
+	electrically_held_switch = "electrically_held_switch",
+	emergency_parking_brake = "emergency_parking_brake",
+	fixed_step_dial = "fixed_step_dial",
+	frequency = "frequency",
+	led = "led",
+	limited_dial = "limited_dial",
+	metadata = "metadata",
+	mission_computer_switch = "mission_computer_switch",
+	multi = "Multi",
+	selector = "selector",
+	toggle_switch = "toggle_switch",
+	variable_step_dial = "variable_step_dial",
+}
+
+return ControlType

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Documentation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Documentation.lua
@@ -1,0 +1,29 @@
+module("Documentation", package.seeall)
+
+local Category = require("Category")
+
+--- @class Documentation: { [string]: Category }
+local Documentation = {}
+
+--- TODO
+--- @return Documentation
+function Documentation:new()
+	--- @type Documentation
+	local o = {}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+--- Gets or adds the specified category
+--- @param category string the name of the category to get or add
+--- @return Category category the new or existing category
+function Documentation:getOrAddCategory(category)
+	if not self[category] then
+		self[category] = Category:new()
+	end
+	return self[category]
+end
+
+return Documentation

--- a/Scripts/DCS-BIOS/lib/modules/documentation/FixedStepInput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/FixedStepInput.lua
@@ -1,0 +1,23 @@
+module("FixedStepInput", package.seeall)
+
+local InputType = require("InputType")
+
+--- @class FixedStepInput: Input
+local FixedStepInput = {}
+
+--- TODO
+--- @param description string
+--- @return FixedStepInput
+function FixedStepInput:new(description)
+	--- @type FixedStepInput
+	local o = {
+		interface = InputType.fixed_step,
+		description = description,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return FixedStepInput

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Input.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Input.lua
@@ -1,0 +1,9 @@
+module("Input", package.seeall)
+
+--- @abstract
+--- @class Input
+--- @field interface InputType
+--- @field description string
+local Input = {}
+
+return Input

--- a/Scripts/DCS-BIOS/lib/modules/documentation/InputType.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/InputType.lua
@@ -1,0 +1,11 @@
+module("InputType", package.seeall)
+
+--- @enum InputType
+local InputType = {
+	action = "action",
+	fixed_step = "fixed_step",
+	set_state = "set_state",
+	variable_step = "variable_step",
+}
+
+return InputType

--- a/Scripts/DCS-BIOS/lib/modules/documentation/IntegerOutput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/IntegerOutput.lua
@@ -1,0 +1,33 @@
+module("IntegerOutput", package.seeall)
+
+local OutputType = require("OutputType")
+
+--- @class IntegerOutput: Output
+--- @field mask integer
+--- @field max_value integer
+--- @field shift_by integer
+local IntegerOutput = {}
+
+--- TODO
+--- @param allocation MemoryAllocation
+--- @param suffix Suffix
+--- @param description string
+--- @return IntegerOutput
+function IntegerOutput:new(allocation, suffix, description)
+	--- @type IntegerOutput
+	local o = {
+		mask = allocation.mask,
+		max_value = allocation.maxValue,
+		shift_by = allocation.shiftBy,
+		address = allocation.address,
+		suffix = suffix,
+		description = description,
+		type = OutputType.integer,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return IntegerOutput

--- a/Scripts/DCS-BIOS/lib/modules/documentation/MomentaryPositions.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/MomentaryPositions.lua
@@ -1,0 +1,10 @@
+module("MomentaryPositions", package.seeall)
+
+--- @enum MomentaryPositions
+local MomentaryPositions = {
+	none = "none",
+	last = "last",
+	first_and_last = "first_and_last",
+}
+
+return MomentaryPositions

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Output.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Output.lua
@@ -1,0 +1,13 @@
+module("Output", package.seeall)
+
+--- @abstract
+--- @class Output
+--- @field address integer
+--- @field suffix Suffix
+--- @field type OutputType
+--- @field description string
+--- @field address_identifier string?
+--- @field address_only_identifier string?
+local Output = {}
+
+return Output

--- a/Scripts/DCS-BIOS/lib/modules/documentation/OutputType.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/OutputType.lua
@@ -1,0 +1,9 @@
+module("OutputType", package.seeall)
+
+--- @enum OutputType
+local OutputType = {
+	integer = "integer",
+	string = "string",
+}
+
+return OutputType

--- a/Scripts/DCS-BIOS/lib/modules/documentation/PhysicalVariant.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/PhysicalVariant.lua
@@ -1,0 +1,14 @@
+module("PhysicalVariant", package.seeall)
+
+--- @enum PhysicalVariant
+local PhysicalVariant = {
+	three_position_switch = "3_position_switch",
+	button_light = "button_light",
+	infinite_rotary = "infinite_rotary",
+	limited_rotary = "limited_rotary",
+	push_button = "push_button",
+	rocker_switch = "rocker_switch",
+	toggle_switch = "toggle_switch",
+}
+
+return PhysicalVariant

--- a/Scripts/DCS-BIOS/lib/modules/documentation/SetStateInput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/SetStateInput.lua
@@ -1,0 +1,26 @@
+module("SetStateInput", package.seeall)
+
+local InputType = require("InputType")
+
+--- @class SetStateInput: Input
+--- @field max_value integer
+local SetStateInput = {}
+
+--- TODO
+--- @param maxValue integer
+--- @param description string
+--- @return SetStateInput
+function SetStateInput:new(maxValue, description)
+	--- @type SetStateInput
+	local o = {
+		interface = InputType.set_state,
+		max_value = maxValue,
+		description = description,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return SetStateInput

--- a/Scripts/DCS-BIOS/lib/modules/documentation/StringOutput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/StringOutput.lua
@@ -1,0 +1,29 @@
+module("StringOutput", package.seeall)
+
+local OutputType = require("OutputType")
+
+--- @class StringOutput: Output
+--- @field maxLength integer
+local StringOutput = {}
+
+--- TODO
+--- @param allocation StringAllocation
+--- @param suffix Suffix
+--- @param description string
+--- @return StringOutput
+function StringOutput:new(allocation, suffix, description)
+	--- @type StringOutput
+	local o = {
+		maxLength = allocation.maxLength,
+		address = allocation.address,
+		suffix = suffix,
+		description = description,
+		type = OutputType.string,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return StringOutput

--- a/Scripts/DCS-BIOS/lib/modules/documentation/Suffix.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/Suffix.lua
@@ -1,0 +1,11 @@
+module("Suffix", package.seeall)
+
+--- @enum Suffix
+local Suffix = {
+	none = "",
+	int = "_INT",
+	str = "_STR",
+	knob_pos = "_KNOB_POS",
+}
+
+return Suffix

--- a/Scripts/DCS-BIOS/lib/modules/documentation/VariableStepInput.lua
+++ b/Scripts/DCS-BIOS/lib/modules/documentation/VariableStepInput.lua
@@ -1,0 +1,28 @@
+module("VariableStepInput", package.seeall)
+
+local InputType = require("InputType")
+
+--- @class VariableStepInput: SetStateInput
+--- @field suggested_step integer
+local VariableStepInput = {}
+
+--- TODO
+--- @param suggestedStep number
+--- @param maxValue number
+--- @param description string
+--- @return VariableStepInput
+function VariableStepInput:new(suggestedStep, maxValue, description)
+	--- @type VariableStepInput
+	local o = {
+		interface = InputType.variable_step,
+		suggested_step = suggestedStep,
+		max_value = maxValue,
+		description = description,
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+return VariableStepInput

--- a/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
@@ -1,0 +1,68 @@
+module("MemoryAllocation", package.seeall)
+
+--- @class MemoryAllocation
+--- @field address integer the memory address
+--- @field maxValue integer the maximum value stored at this memory location
+--- @field memoryMapEntry MemoryMapEntry the memory map entry
+--- @field multiplier integer TODO
+--- @field mask integer TODO
+--- @field shiftBy integer TODO
+--- @field value integer? the current value
+local MemoryAllocation = {}
+
+--- Creates a new memory allocation
+--- @param max_value number
+--- @param entry MemoryMapEntry
+--- @param shift_by number
+--- @param bits_required number
+--- @return MemoryAllocation
+function MemoryAllocation:new(max_value, entry, shift_by, bits_required)
+	--- @type MemoryAllocation
+	local o = {
+		address = entry.address,
+		maxValue = max_value,
+		memoryMapEntry = entry,
+		multiplier = math.pow(2, shift_by),
+		mask = (math.pow(2, bits_required) - 1) * math.pow(2, shift_by),
+		shiftBy = shift_by,
+	}
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+--- Stores a new value in the current memory allocation
+--- @param value number?
+function MemoryAllocation:setValue(value)
+	-- ignore nil values (on MP servers with player export disabled, some values are not available)
+	if value == nil then
+		return
+	end
+	if value ~= value then
+		-- check for NaN (Not a Number)
+		return
+	end
+	assert(self.maxValue)
+	assert(value)
+	value = math.floor(value)
+	if value < 0 then
+		BIOS.log(
+			string.format("Util.lua: value %f is too small for address %d mask %d", value, self.address, self.mask)
+		)
+		return
+	end
+	if value > self.maxValue then
+		BIOS.log(
+			string.format("Util.lua: value %f is too large for address %d mask %d", value, self.address, self.mask)
+		)
+		return
+	end
+	assert(value >= 0)
+	assert(value <= self.maxValue)
+	if self.value ~= value then
+		self.value = value
+		self.memoryMapEntry.dirty = true
+	end
+end
+
+return MemoryAllocation

--- a/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryMap.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryMap.lua
@@ -1,0 +1,195 @@
+module("MemoryMap", package.seeall)
+
+local MemoryMapEntry = require("MemoryMapEntry")
+local StringAllocation = require("StringAllocation")
+
+--- @class MemoryMap
+--- @field baseAddress number the base address
+--- @field lastAddress number TODO
+--- @field autosyncPosition number TODO
+--- @field entries { [number]: MemoryMapEntry } TODO
+local MemoryMap = {}
+
+--- Constructs a new memory map
+--- @param baseAddress number the base address
+--- @return MemoryMap
+function MemoryMap:new(baseAddress)
+	--- @type MemoryMap
+	local o = {
+		baseAddress = baseAddress,
+		lastAddress = baseAddress,
+		autosyncPosition = baseAddress,
+		entries = {
+			[baseAddress] = MemoryMapEntry:new(baseAddress),
+		},
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+function MemoryMap:autosyncStep()
+	-- set a non-dirty value to dirty
+	self.autosyncPosition = self.autosyncPosition + 2
+	if self.autosyncPosition > self.lastAddress then
+		self.autosyncPosition = self.baseAddress -- wrap around
+	end
+	local entry = self:getOrAddEntry(self.autosyncPosition)
+	entry:setDirtyIfAble()
+end
+
+--- Gets all data that has been written and resets the dirty bit, marking it as read
+--- @return string
+function MemoryMap:flushData()
+	-- Return a string containing a sequence of write accesses
+	-- that contain all entries marked as dirty.
+	-- Resets the "dirty bit".
+
+	local ret = ""
+
+	local address = self.baseAddress
+	local entry = self:getOrAddEntry(address)
+
+	-- advance to the first entry that has changed
+	while address <= self.lastAddress do
+		entry = self:getOrAddEntry(address)
+		if entry.dirty then
+			break
+		end
+		address = address + 2
+	end
+	if not entry.dirty then
+		-- no changes at all
+		return ""
+	end
+
+	-- prepare write access
+	local writeStartAddress = address
+	local writeLength = 2
+	local writeData = MemoryMap.encodeInt(entry:getValue())
+	local lastWriteDataAddress = address
+	entry.dirty = false
+	address = address + 2
+
+	while address <= self.lastAddress do
+		entry = self:getOrAddEntry(address)
+		-- advance to the next changed value
+		if entry.dirty then
+			-- figure out whether to start a new write request
+			if (address - lastWriteDataAddress <= 6) and entry:getValue() ~= 0x5555 then
+				-- append to current write request
+				local a = lastWriteDataAddress + 2
+				while a <= address do
+					writeLength = writeLength + 2
+					writeData = writeData .. MemoryMap.encodeInt(self:getOrAddEntry(a):getValue())
+					a = a + 2
+				end
+				lastWriteDataAddress = address
+				assert(address == a - 2)
+			else
+				-- start new write request
+				ret = ret .. MemoryMap.encodeInt(writeStartAddress) .. MemoryMap.encodeInt(writeLength) .. writeData
+				writeStartAddress = address
+				writeLength = 2
+				writeData = MemoryMap.encodeInt(entry:getValue())
+				lastWriteDataAddress = address
+			end
+			entry.dirty = false
+		end
+		address = address + 2
+	end
+
+	return ret .. MemoryMap.encodeInt(writeStartAddress) .. MemoryMap.encodeInt(writeLength) .. writeData
+end
+
+--- Retrieves an existing memory map entry for a given address, or creates a new one
+--- @param address integer the memory address for which to retrieve an entry
+--- @return MemoryMapEntry
+function MemoryMap:getOrAddEntry(address)
+	if self.entries[address] == nil then
+		-- initialize new entry
+		self.entries[address] = MemoryMapEntry:new(address)
+		self.lastAddress = address
+	end
+	return self.entries[address]
+end
+
+--- Sets the values of all allocations within the map to nil
+function MemoryMap:clearValues()
+	for _, entry in pairs(self.entries) do
+		for _, alloc in pairs(entry.allocations) do
+			alloc.value = nil
+			-- alloc.dirty = false -- TODO: seems unused?
+		end
+	end
+end
+
+--- Allocates space for a new integer value
+--- @param max_value integer
+--- @return MemoryAllocation allocation the newly-created memory allocation
+function MemoryMap:allocateInt(max_value)
+	return self:allocateData(max_value, false, false)
+end
+
+--- Allocates space for a new string value
+--- @param max_length number the max length of the string
+--- @return StringAllocation
+function MemoryMap:allocateString(max_length)
+	--- @type MemoryAllocation[]
+	local character_allocations = {}
+
+	character_allocations[1] = self:allocateData(255, true, true)
+	for i = 2, max_length, 1 do
+		character_allocations[i] = self:allocateData(255, true, false)
+	end
+
+	return StringAllocation:new(character_allocations, max_length)
+end
+
+--- @private
+--- Allocates space in the memory map for data whose value may be between 0 and max_value
+--- @param max_value integer the maximum integer value stored in the memory allocation
+--- @param is_string_character boolean whether the space is being allocated for a string character
+--- @param first_string_character boolean whether this is the first character of a string
+--- @return MemoryAllocation
+function MemoryMap:allocateData(max_value, is_string_character, first_string_character)
+	-- allocate space for an integer value from 0 to maxValue in the memory map
+	-- returns a MemoryAllocation object that has a setValue() method
+	-- if is_string_character is true, the allocation will be in a byte-aligned
+	-- position at the end of the memory map. Consecutive calls with is_string_character
+	-- set will allocate consecutive bytes in the memory map.
+
+	local address = nil
+	if is_string_character then
+		address = self.lastAddress
+	else
+		address = self.baseAddress
+	end
+
+	while true do
+		local entry = self:getOrAddEntry(address)
+
+		if
+			entry:canAllocate(max_value) -- make sure we have space for the value
+			and ((not is_string_character) or entry:canAllocateStringCharacter(first_string_character)) -- string characters have special rules
+		then
+			-- found an entry that has enough space for the number of bits we want to allocate
+			return entry:allocate(max_value)
+		else
+			address = address + 2
+		end
+	end
+end
+
+--- @private
+function MemoryMap.encodeInt(intval)
+	assert(intval >= 0)
+	assert(intval <= 65535)
+	-- convert value (a float from 0.0 to 1.0) to a 16-bit signed integer from 0 to 65535
+	local lowbyte = intval % 256
+	local highbyte = (intval - lowbyte) / 256
+	return string.char(lowbyte, highbyte)
+end
+
+return MemoryMap

--- a/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryMapEntry.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryMapEntry.lua
@@ -1,0 +1,89 @@
+module("MemoryMapEntry", package.seeall)
+
+local MemoryAllocation = require("MemoryAllocation")
+
+--- @class MemoryMapEntry
+--- @field address number the memory address of the entry
+--- @field private allocatedBitCounter integer the number of bits currently allocated
+--- @field dirty boolean whether any value in the entry has changed since the last update
+--- @field allocations MemoryAllocation[] TODO is this just memoryallocation? what about stringallocation?
+local MemoryMapEntry = {}
+
+--- Creates a new memory map entry
+--- @param address number the memory address
+--- @return unknown
+function MemoryMapEntry:new(address)
+	--- @type MemoryMapEntry
+	local o = {
+		address = address,
+		allocatedBitCounter = 0,
+		dirty = false,
+		allocations = {},
+	}
+
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+function MemoryMapEntry:getValue()
+	local ret = 0
+	for _, alloc in ipairs(self.allocations) do
+		if alloc.value ~= nil then
+			ret = ret + (alloc.value * alloc.multiplier)
+		end
+	end
+	return ret
+end
+
+function MemoryMapEntry:setDirtyIfAble()
+	for _, alloc in ipairs(self.allocations) do
+		if alloc.value ~= nil then
+			self.dirty = true
+			return
+		end
+	end
+end
+
+--- Allocates space in this entry to store a value which is less than or equal to the provided max value
+--- @param max_value integer the maximum value that will be stored in this space
+--- @return MemoryAllocation allocation the new memory allocation for the provided value
+function MemoryMapEntry:allocate(max_value)
+	assert(self:canAllocate(max_value))
+	local bits_required = MemoryMapEntry.bitsRequiredForValue(max_value)
+	local shift_by = self.allocatedBitCounter
+	local alloc = MemoryAllocation:new(max_value, self, shift_by, bits_required)
+	self.allocatedBitCounter = self.allocatedBitCounter + bits_required
+	table.insert(self.allocations, alloc)
+	return alloc
+end
+
+--- Determines whether the entry has enough space available to allocate more for a given max value
+--- @param max_value integer the maximum value that will be stored
+--- @return boolean can_allocate whether the entry has space available to allocate for the provided max value
+function MemoryMapEntry:canAllocate(max_value)
+	local bits_required = MemoryMapEntry.bitsRequiredForValue(max_value)
+	return (16 - self.allocatedBitCounter) >= bits_required
+end
+
+--- Determines whether the entry has enough space available to allocate a string character
+--- @param first_character boolean whether the character to be allocated is the first character of a string
+--- @return boolean can_allocate whether the entry has space available to allocate a string character
+function MemoryMapEntry:canAllocateStringCharacter(first_character)
+	if first_character then
+		return self.allocatedBitCounter == 0
+	end -- the first character of a string must start at 0
+	return self.allocatedBitCounter == 0 or self.allocatedBitCounter == 8 -- if it's not the first character, we can double up if needed
+end
+
+--- @private
+function MemoryMapEntry.bitsRequiredForValue(max_value)
+	return math.ceil(MemoryMapEntry.log2(max_value + 1))
+end
+
+--- @private
+function MemoryMapEntry.log2(n)
+	return math.log(n) / math.log(2)
+end
+
+return MemoryMapEntry

--- a/Scripts/DCS-BIOS/lib/modules/memory_map/StringAllocation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/StringAllocation.lua
@@ -1,0 +1,45 @@
+module("StringAllocation", package.seeall)
+
+--- @class StringAllocation A class containing a set of memory allocations which make up a string
+--- @field address integer the memory address
+--- @field maxLength integer the maximum length of the string
+--- @field characterAllocations MemoryAllocation[] the memory allocations which make up the string
+local StringAllocation = {}
+
+--- Constructs a new StringAllocation
+--- @param characterAllocations MemoryAllocation[] the memory allocations which make up the string
+--- @param max_length integer the maximum length of the string
+--- @return StringAllocation
+function StringAllocation:new(characterAllocations, max_length)
+	--- @type StringAllocation
+	local o = {
+		address = characterAllocations[1].address,
+		maxLength = max_length,
+		characterAllocations = characterAllocations,
+	}
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
+
+--- Updates the constituent memory allocations to store the provided string
+--- @param value string the new value to store
+function StringAllocation:setValue(value)
+	local i = 1
+
+	if value == nil then
+		BIOS.log(string.format("Util.lua: item is sending a nil value"))
+		return
+	end
+
+	while i <= value:len() and i <= #self.characterAllocations do
+		self.characterAllocations[i]:setValue(value:byte(i))
+		i = i + 1
+	end
+	while i <= #self.characterAllocations do
+		self.characterAllocations[i]:setValue(32) -- space
+		i = i + 1
+	end
+end
+
+return StringAllocation

--- a/Scripts/DCS-BIOS/test/AircraftTest.lua
+++ b/Scripts/DCS-BIOS/test/AircraftTest.lua
@@ -1,0 +1,50 @@
+local lu = require("luaunit")
+
+-- Unit testing starts
+TestAircraft = {} --class
+
+function TestAircraft:testA4EC()
+	self:validateModule(require("A-4E-C"), "A-4E-C", 0x8400)
+end
+
+function TestAircraft:testP51D()
+	self:validateModule(require("P-51D"), "P-51D", 0x5000)
+end
+
+--- Validates a module is as expected and that control names are valid
+--- @param module Module
+--- @param expected_name string
+--- @param expected_address integer
+function TestAircraft:validateModule(module, expected_name, expected_address)
+	lu.assertEquals(module.name, expected_name)
+	lu.assertEquals(module.memoryMap.baseAddress, expected_address)
+	self:validateControlNames(module.name, module.documentation)
+end
+
+--- Validates that all control names follow the defined pattern and that there are no duplicates
+--- @param documentation Documentation
+function TestAircraft:validateControlNames(module_name, documentation)
+	local all_keys = {}
+	for _, category in pairs(documentation) do
+		for identifier in pairs(category) do
+			-- ensure all codes:
+			--   are all uppercase
+			--   start with a letter
+			--   end with a letter or number
+			--   contain only letters, numbers, and underscores
+			local identifier_pattern = "^%u[%u%d_]*[%u%d]$"
+			lu.assertNotIsNil(
+				identifier:match(identifier_pattern),
+				module_name .. ": " .. "id " .. identifier .. " did not meet id requirements"
+			)
+			--   don't have any consecutive underscores
+			lu.assertNotStrContains(identifier, "__", false)
+
+			-- verify this key is not a duplicate
+			lu.assertNotTableContains(all_keys, identifier)
+			all_keys[identifier] = true
+		end
+	end
+end
+
+-- class TestModule

--- a/Scripts/DCS-BIOS/test/MemoryMapEntryTest.lua
+++ b/Scripts/DCS-BIOS/test/MemoryMapEntryTest.lua
@@ -1,0 +1,107 @@
+local MemoryMapEntry = require("MemoryMapEntry")
+local StringAllocation = require("StringAllocation")
+
+local lu = require("luaunit")
+
+--- @class TestMemoryMapEntry
+--- @field entry MemoryMapEntry
+TestMemoryMapEntry = {}
+local entry_address = 0x4200
+
+function TestMemoryMapEntry:setUp()
+	self.entry = MemoryMapEntry:new(entry_address)
+end
+
+function TestMemoryMapEntry:testCreateMemoryMapEntry()
+	local entry = self.entry
+	lu.assertEquals(entry.address, entry_address)
+	lu.assertEquals(#entry.allocations, 0)
+	lu.assertIsFalse(entry.dirty)
+end
+
+function TestMemoryMapEntry:testCanAllocate()
+	local entry = self.entry
+	lu.assertIsTrue(entry:canAllocate(42)) -- this should be well below the available space
+	lu.assertIsTrue(entry:canAllocate(65535)) -- the limit of the space available
+	lu.assertIsFalse(entry:canAllocate(65536)) -- one above the limit of the space available
+
+	local allocation = entry:allocate(255)
+	lu.assertEquals(allocation.address, entry.address)
+	lu.assertEquals(allocation.mask, 255)
+	lu.assertEquals(allocation.maxValue, 255)
+	lu.assertEquals(allocation.multiplier, 1)
+	lu.assertEquals(allocation.shiftBy, 0)
+	lu.assertIsNil(allocation.value)
+	lu.assertEquals(#entry.allocations, 1)
+
+	lu.assertIsTrue(entry:canAllocate(255)) -- we can still fit more
+	lu.assertIsFalse(entry:canAllocate(65535)) -- but not the max anymore
+
+	local allocation2 = entry:allocate(255)
+	lu.assertEquals(allocation2.address, entry.address)
+	lu.assertEquals(allocation2.mask, 65280)
+	lu.assertEquals(allocation2.maxValue, 255)
+	lu.assertEquals(allocation2.multiplier, 256)
+	lu.assertEquals(allocation2.shiftBy, 8)
+	lu.assertIsNil(allocation2.value)
+	lu.assertEquals(#entry.allocations, 2)
+end
+
+function TestMemoryMapEntry:testCanAllocateString()
+	local entry = self.entry
+	lu.assertIsTrue(entry:canAllocateStringCharacter(true)) -- nothing has been allocated, so this is fine
+	lu.assertIsTrue(entry:canAllocateStringCharacter(false)) -- nothing has been allocated, so this is fine
+
+	entry:allocate(255)
+	lu.assertIsFalse(entry:canAllocateStringCharacter(true)) -- can't allocate the first character anymore
+	lu.assertIsTrue(entry:canAllocateStringCharacter(false)) -- but we can still stack on top of this
+
+	entry:allocate(255)
+	lu.assertIsFalse(entry:canAllocateStringCharacter(true)) -- now we can't fit anything anymore
+	lu.assertIsFalse(entry:canAllocateStringCharacter(false))
+end
+
+function TestMemoryMapEntry:testGetValue()
+	local entry = self.entry
+	local allocation = entry:allocate(255)
+	allocation:setValue(10)
+
+	lu.assertEquals(entry:getValue(), 10)
+
+	local allocation2 = entry:allocate(255)
+	allocation2:setValue(5)
+
+	lu.assertEquals(entry:getValue(), 1290) -- 10 + (5 * 255)
+end
+
+function TestMemoryMapEntry:testMemoryAllocation()
+	local entry = self.entry
+
+	local alloc = entry:allocate(255)
+
+	alloc:setValue(300) -- values larger than max shouldn't work
+	lu.assertEquals(entry:getValue(), 0)
+	lu.assertIsFalse(entry.dirty)
+
+	alloc:setValue(-1) -- nor should any below zero
+	lu.assertEquals(entry:getValue(), 0)
+	lu.assertIsFalse(entry.dirty)
+
+	alloc:setValue(10)
+	lu.assertEquals(entry:getValue(), 10)
+	lu.assertIsTrue(entry.dirty)
+end
+
+function TestMemoryMapEntry:testStringAllocation()
+	local entry = self.entry
+
+	local alloc1 = entry:allocate(255)
+	local alloc2 = entry:allocate(255)
+
+	local allocation = StringAllocation:new({ alloc1, alloc2 }, 2)
+	allocation:setValue("hi")
+
+	lu.assertEquals(alloc1.value, string.byte("h"))
+	lu.assertEquals(alloc2.value, string.byte("i"))
+	lu.assertIsTrue(entry.dirty)
+end

--- a/Scripts/DCS-BIOS/test/MemoryMapTest.lua
+++ b/Scripts/DCS-BIOS/test/MemoryMapTest.lua
@@ -1,0 +1,68 @@
+local MemoryMap = require("MemoryMap")
+
+local lu = require("luaunit")
+
+--- @class TestMemoryMap
+--- @field memory_map MemoryMap
+TestMemoryMap = {}
+local memory_map_address = 0x4200
+
+function TestMemoryMap:setUp()
+	self.memory_map = MemoryMap:new(memory_map_address)
+end
+
+function TestMemoryMap:testCreateMemoryMap()
+	local map = self.memory_map
+	lu.assertEquals(map.baseAddress, memory_map_address)
+	lu.assertEquals(#map.entries, 0)
+	lu.assertEquals(map.lastAddress, memory_map_address)
+	lu.assertEquals(map.autosyncPosition, memory_map_address)
+end
+
+function TestMemoryMap:testAllocateInt()
+	local map = self.memory_map
+	local allocation = map:allocateInt(255)
+
+	lu.assertEquals(allocation.address, memory_map_address)
+
+	allocation:setValue(10)
+
+	lu.assertEquals(allocation.value, 10)
+
+	lu.assertEquals(map.lastAddress, memory_map_address)
+
+	local allocation2 = map:allocateInt(65535)
+
+	lu.assertEquals(map.lastAddress, memory_map_address + 2)
+	lu.assertEquals(allocation2.address, memory_map_address + 2)
+end
+
+function TestMemoryMap:testAllocateString()
+	local map = self.memory_map
+	local allocation = map:allocateString(5)
+	allocation:setValue("hello")
+
+	lu.assertEquals(allocation.address, memory_map_address)
+	lu.assertEquals(map.lastAddress, memory_map_address + 4) -- incremented by two every two characters
+	lu.assertNotIsNil(map.entries[memory_map_address]) -- he
+	lu.assertNotIsNil(map.entries[memory_map_address + 2]) -- ll
+	lu.assertNotIsNil(map.entries[memory_map_address + 4]) -- o
+	lu.assertIsNil(map.entries[memory_map_address - 2])
+	lu.assertIsNil(map.entries[memory_map_address + 6])
+end
+
+function TestMemoryMap:testClearValues()
+	local map = self.memory_map
+	local entry = map:getOrAddEntry(memory_map_address)
+	local allocation = entry:allocate(255)
+	allocation:setValue(128)
+
+	lu.assertEquals(allocation.value, 128)
+	lu.assertEquals(entry:getValue(), 128)
+
+	map:clearValues()
+
+	entry = map:getOrAddEntry(memory_map_address)
+	lu.assertEquals(entry:getValue(), 0)
+	lu.assertIsNil(allocation.value)
+end

--- a/Scripts/DCS-BIOS/test/ModuleTest.lua
+++ b/Scripts/DCS-BIOS/test/ModuleTest.lua
@@ -1,0 +1,559 @@
+local ActionArgument = require("ActionArgument")
+local ApiVariant = require("ApiVariant")
+local ControlType = require("ControlType")
+local InputType = require("InputType")
+local Module = require("Module")
+local OutputType = require("OutputType")
+local PhysicalVariant = require("PhysicalVariant")
+local Suffix = require("Suffix")
+
+local lu = require("luaunit")
+
+--- @class TestModule
+--- @field module Module
+TestModule = {}
+local moduleName = "MyModule"
+local moduleAddress = 0x4200
+
+function TestModule:setUp()
+	self.module = Module:new(moduleName, moduleAddress, {})
+end
+
+function TestModule:testCreateModule()
+	lu.assertEquals(self.module.name, moduleName)
+	lu.assertEquals(self.module.memoryMap.baseAddress, moduleAddress)
+end
+
+function TestModule:testAddFloat()
+	local id = "MY_FLOAT"
+	local arg_number = 1
+	local limits = { 0, 1 }
+	local category = "Floats"
+	local description = "This is a float"
+
+	local control = self.module:defineFloat(id, arg_number, limits, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.analog_gauge)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 0)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 65535)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddIndicatorLight()
+	local id = "MY_LIGHT"
+	local arg_number = 1
+	local category = "Lights"
+	local description = "This is a light"
+
+	local control = self.module:defineIndicatorLight(id, arg_number, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.led)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 0)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 1)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddPushButton()
+	local id = "MY_PUSH_BUTTON"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local category = "Push Buttons"
+	local description = "This is a push button"
+
+	local control = self.module:definePushButton(id, device_id, command, arg_number, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.push_button)
+	lu.assertEquals(control.api_variant, ApiVariant.momentary_last_position)
+
+	lu.assertEquals(#control.inputs, 3)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local set_state_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(set_state_input.interface, InputType.set_state)
+	lu.assertEquals(set_state_input.max_value, 1)
+
+	local action_input = control.inputs[3] --[[@as ActionInput]]
+	lu.assertEquals(action_input.interface, InputType.action)
+	lu.assertEquals(action_input.argument, ActionArgument.toggle)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 1)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddPotentiometer()
+	local id = "MY_POTENTIOMETER"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local limits = { 0, 1 }
+	local category = "Potentiometers"
+	local description = "This is a potentiometer"
+
+	local control = self.module:definePotentiometer(id, device_id, command, arg_number, limits, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.limited_dial)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 2)
+
+	local set_state_input = control.inputs[1] --[[@as SetStateInput]]
+	lu.assertEquals(set_state_input.interface, InputType.set_state)
+	lu.assertEquals(set_state_input.max_value, 65535)
+
+	local variable_step_input = control.inputs[2] --[[@as VariableStepInput]]
+	lu.assertEquals(variable_step_input.interface, InputType.variable_step)
+	lu.assertEquals(variable_step_input.max_value, 65535)
+	lu.assertEquals(variable_step_input.suggested_step, 3200)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 65535)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddToggleSwitch()
+	local id = "MY_TOGGLE_SWITCH"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local category = "Toggle Switches"
+	local description = "This is a toggle switch"
+
+	local control = self.module:defineToggleSwitch(id, device_id, command, arg_number, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.toggle_switch)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 3)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local set_state_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(set_state_input.interface, InputType.set_state)
+	lu.assertEquals(set_state_input.max_value, 1)
+
+	local action_input = control.inputs[3] --[[@as ActionInput]]
+	lu.assertEquals(action_input.interface, InputType.action)
+	lu.assertEquals(action_input.argument, ActionArgument.toggle)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 1)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddMultipositionSwitch()
+	local id = "MY_MULTIPOSITION_SWITCH"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local num_positions = 5
+	local increment = 0.1
+	local category = "Multiposition Switches"
+	local description = "This is a multiposition switch"
+
+	local control = self.module:defineMultipositionSwitch(
+		id,
+		device_id,
+		command,
+		arg_number,
+		num_positions,
+		increment,
+		category,
+		description
+	)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.toggle_switch)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 2)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local set_state_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(set_state_input.interface, InputType.set_state)
+	lu.assertEquals(set_state_input.max_value, num_positions - 1)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, num_positions - 1)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddRotary()
+	local id = "MY_ROTARY"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local category = "Rotaries"
+	local description = "This is a rotary"
+
+	local control = self.module:defineRotary(id, device_id, command, arg_number, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.analog_dial)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertEquals(control.api_variant, ApiVariant.multiturn)
+	lu.assertEquals(#control.inputs, 1)
+
+	local variable_step_input = control.inputs[1] --[[@as VariableStepInput]]
+	lu.assertEquals(variable_step_input.interface, InputType.variable_step)
+	lu.assertEquals(variable_step_input.max_value, 65535)
+	lu.assertEquals(variable_step_input.suggested_step, 3200)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 65535)
+	lu.assertEquals(output.suffix, Suffix.knob_pos)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAdd3PosTumb()
+	local id = "MY_3POS_TUMB"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local category = "Three-Position tumbs"
+	local description = "This is a 3-pos tumb"
+
+	local control = self.module:define3PosTumb(id, device_id, command, arg_number, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.three_position_switch)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 2)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local set_state_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(set_state_input.interface, InputType.set_state)
+	lu.assertEquals(set_state_input.max_value, 2)
+
+	lu.assertEquals(#control.outputs, 1)
+	local output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(output.type, OutputType.integer)
+	lu.assertEquals(output.max_value, 2)
+	lu.assertEquals(output.suffix, Suffix.none)
+	lu.assertEquals(output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddFixedStepTumb()
+	local id = "MY_FIXED_STEP_TUMB"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local step = 0.1
+	local limits = { 0, 0.9 }
+	local rel_args = { -0.1, 0.1 }
+	local output_map = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }
+	local category = "Fixed-step Tumbs"
+	local description = "This is a fixed-step tumb"
+
+	local control = self.module:defineFixedStepTumb(
+		id,
+		device_id,
+		command,
+		arg_number,
+		step,
+		limits,
+		rel_args,
+		output_map,
+		category,
+		description
+	)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.discrete_dial)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.infinite_rotary)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 1)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	lu.assertEquals(#control.outputs, 2)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 9)
+	lu.assertEquals(integer_output.suffix, Suffix.int)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+
+	local string_output = control.outputs[2] --[[@as StringOutput]]
+	lu.assertEquals(string_output.type, OutputType.string)
+	lu.assertEquals(string_output.maxLength, 1)
+	lu.assertEquals(string_output.suffix, Suffix.str)
+
+	lu.assertEquals(string_output.address, moduleAddress + 2) -- string will require new address
+end
+
+function TestModule:testAddFixedStepInput()
+	local id = "MY_FIXED_STEP_INPUT"
+	local device_id = 1
+	local command = 2
+	local rel_args = { -0.1, 0.1 }
+	local category = "Fixed-step Inputs"
+	local description = "This is a fixed-step input"
+
+	local control = self.module:defineFixedStepInput(id, device_id, command, rel_args, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.fixed_step_dial)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 1)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	lu.assertEquals(#control.outputs, 0)
+end
+
+function TestModule:testAddRadioWheel()
+	local id = "MY_RADIO_WHEEL"
+	local device_id = 1
+	local decrement_command = 2
+	local increment_command = 3
+	local arg_number = 4
+	local rel_args = { -0.1, 0.1 }
+	local step = 0.05
+	local limits = { 0.15, 0.80 }
+	local output_map = { " 3", " 4", " 5", " 6", " 7", " 8", " 9", "10", "11", "12", "13", "14", "15" }
+	local category = "Radio Wheels"
+	local description = "This is a radio wheel"
+
+	local control = self.module:defineRadioWheel(
+		id,
+		device_id,
+		decrement_command,
+		increment_command,
+		rel_args,
+		arg_number,
+		step,
+		limits,
+		output_map,
+		category,
+		description
+	)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.discrete_dial)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.infinite_rotary)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 1)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	lu.assertEquals(#control.outputs, 2)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 12)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+	lu.assertEquals(integer_output.suffix, Suffix.int)
+
+	local string_output = control.outputs[2] --[[@as StringOutput]]
+	lu.assertEquals(string_output.type, OutputType.string)
+	lu.assertEquals(string_output.maxLength, 2)
+	lu.assertEquals(string_output.suffix, Suffix.str)
+
+	lu.assertEquals(string_output.address, moduleAddress + 2) -- string will require new address
+end
+
+function TestModule:testAddIntegerFromGetter()
+	function TestModule:testAddTumbNoCycle()
+		local id = "MY_INT_GETTER"
+		local getter = function(dev0) end
+		local max_value = 255
+		local category = "Integer Getters"
+		local description = "This is an integer getter"
+
+		local control = self.module:defineIntegerFromGetter(id, getter, max_value, category, description)
+
+		lu.assertEquals(control, self.module.documentation[category][id])
+		lu.assertEquals(control.control_type, ControlType.metadata)
+		lu.assertEquals(control.category, category)
+		lu.assertEquals(control.description, description)
+		lu.assertEquals(control.identifier, id)
+		lu.assertIsNil(control.physical_variant)
+		lu.assertIsNil(control.api_variant)
+
+		lu.assertEquals(#control.inputs, 0)
+
+		lu.assertEquals(#control.outputs, 1)
+		local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+		lu.assertEquals(integer_output.type, OutputType.integer)
+		lu.assertEquals(integer_output.max_value, max_value)
+		lu.assertEquals(integer_output.suffix, Suffix.none)
+		lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+	end
+end
+
+function TestModule:testAddTumbNoCycle()
+	local id = "MY_TUMB"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local step = 0.1
+	local limits = { 0, 0.9 }
+	local cycle = false
+	local output_map = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9" }
+	local category = "Tumbs"
+	local description = "This is a tumb"
+
+	local control = self.module:defineTumb(
+		id,
+		device_id,
+		command,
+		arg_number,
+		step,
+		limits,
+		output_map,
+		cycle,
+		category,
+		description
+	)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.limited_rotary)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 2)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local fixed_step_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.set_state)
+	lu.assertEquals(fixed_step_input.max_value, 9)
+
+	lu.assertEquals(#control.outputs, 2)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 9)
+	lu.assertEquals(integer_output.suffix, Suffix.int)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+
+	local string_output = control.outputs[2] --[[@as StringOutput]]
+	lu.assertEquals(string_output.type, OutputType.string)
+	lu.assertEquals(string_output.maxLength, 1)
+	lu.assertEquals(string_output.suffix, Suffix.str)
+
+	lu.assertEquals(string_output.address, moduleAddress + 2) -- string will require new address
+end
+
+function TestModule:testAddTumbCycle()
+	local id = "MY_TUMB"
+	local device_id = 1
+	local command = 2
+	local arg_number = 3
+	local step = 0.1
+	local limits = { 0, 0.9 }
+	local cycle = true
+	local category = "Tumbs"
+	local description = "This is a tumb"
+
+	local control =
+		self.module:defineTumb(id, device_id, command, arg_number, step, limits, nil, cycle, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.selector)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertEquals(control.physical_variant, PhysicalVariant.infinite_rotary)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 2)
+	local fixed_step_input = control.inputs[1] --[[@as FixedStepInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.fixed_step)
+
+	local fixed_step_input = control.inputs[2] --[[@as SetStateInput]]
+	lu.assertEquals(fixed_step_input.interface, InputType.set_state)
+	lu.assertEquals(fixed_step_input.max_value, 9)
+
+	lu.assertEquals(#control.outputs, 1)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 9)
+	lu.assertEquals(integer_output.suffix, Suffix.none)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+-- todo: add tests for adding multiple controls

--- a/Scripts/DCS-BIOS/test/TestSuite.lua
+++ b/Scripts/DCS-BIOS/test/TestSuite.lua
@@ -14,6 +14,10 @@ package.path = "./Scripts/DCS-BIOS/lib/modules/memory_map/?.lua;" .. package.pat
 BIOS = {}
 function BIOS.log(str) end -- noop
 
+require("AircraftTest") -- high-level tests for specific aircraft
+require("MemoryMapTest") -- unit tests for the memory map
+require("MemoryMapEntryTest") -- unit tests for memory map entries
+require("ModuleTest") -- unit tests for core aircraft module functionality
 require("ServerTest") -- unit tests for tcp/udp server code
 
 local lu = require("luaunit")


### PR DESCRIPTION
This adds typing for the core MemoryMap and Documentation tables, and migrates the A-4E-C and P-51D to table-based modules.

For the most part, module definition is unchanged. The generated json files are identical, meaning address assignment logic has been preserved and this will have no impact to clients.

This doesn't _fully_ remove global variables as there are still a few that are more deeply embedded, so I've kept that functionality in Protocol.lua and added some wrapper functions to maintain that functionality. I'd like to remove them in the future.

I've left lots of documentation marked as TODO as I just don't know the full reasoning for the existence of some of these items that appear in the json.

Unit tests have been added for the control definition functionality that has been migrated thus far. As we migrate more, it will be imperative to continue adding unit tests to verify functionality.