### PR TITLE
Add action to auto-release commits to master

### DIFF
--- a/.github/workflows/release-openbeta.yml
+++ b/.github/workflows/release-openbeta.yml
@@ -1,0 +1,51 @@
+name: Release latest openbeta
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  RELEASE_FILE_NAME: 'DCS-BIOS_openbeta.zip'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    name: Release zip file
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.1
+        with:
+          type: zip
+          filename: 'DCS-BIOS_openbeta.zip'
+          directory: './Scripts'
+          exclusions: '/*test/*'
+
+      - name: Update latest tag
+        uses: rickstaa/action-create-tag@v1
+        id: tag_create
+        with:
+          tag: latest
+          force_push_tag: true
+          message: Latest release
+
+      - name: Upload Release
+        uses: ncipollo/release-action@v1.12.0
+        with:
+          allowUpdates: true
+          artifactErrorsFailBuild: true
+          artifacts: './Scripts/DCS-BIOS_openbeta.zip'
+          commit: master
+          makeLatest: true
+          name: DCS-BIOS Openbeta
+          prerelease: true
+          removeArtifacts: true
+          tag: latest
+          updateOnlyUnreleased: true


### PR DESCRIPTION
Whenever code is pushed to master, this will create a new prerelease with data zipped exactly like the current releases, automatically.

This works by updating the `latest` tag to the current commit on master, zipping the contents of the `Scripts` folder (ignoring the `test` subfolder), and then creating or updating a release for the `latest` tag with that zip file attached. No action is required by anyone, and this will happen automatically when code is pushed or merged to master.

This means we no longer have to instruct openbeta users to download the entire repo as a zip file, which also requires them to download many other things they don't need. This release will always be kept up to date automatically.

![image](https://github.com/DCS-Skunkworks/dcs-bios/assets/30303272/23fa40e1-0ed8-444d-9bf7-d861d6cda5a7)
