### PR TITLE
Consolidate LoGetAircraftDrawArgumentValue calls

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/Module.lua
+++ b/Scripts/DCS-BIOS/lib/modules/Module.lua
@@ -417,6 +417,34 @@ end
 
 --- Adds a new integer output based on a custom getter function
 --- @param identifier string the unique identifier for the control
+--- @param draw_arg_id integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineBitFromDrawArgument(identifier, draw_arg_id, category, description)
+	return self:defineIntegerFromGetter(identifier, function()
+		if LoGetAircraftDrawArgumentValue(draw_arg_id) > 0 then
+			return 1
+		else
+			return 0
+		end
+	end, 1, category, description)
+end
+
+--- Adds a new integer output based on a custom getter function
+--- @param identifier string the unique identifier for the control
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Module:defineFloatFromDrawArgument(identifier, arg_number, category, description)
+	return self:defineIntegerFromGetter(identifier, function()
+		return math.floor(LoGetAircraftDrawArgumentValue(arg_number) * 65535)
+	end, 65535, category, description)
+end
+
+--- Adds a new integer output based on a custom getter function
+--- @param identifier string the unique identifier for the control
 --- @param getter fun(): integer the getter function which will return an integer
 --- @param maxValue integer the maximum value the getter will return
 --- @param category string the category in which the control should appear

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-4E-C.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-4E-C.lua
@@ -423,75 +423,22 @@ A_4E_C:define3PosTumb("ASN41_LAT_SLEW", 23, 3165, 248, "Doppler Nav", "ASN-41 De
 A_4E_C:define3PosTumb("ASN41_LON_SLEW", 23, 3166, 249, "Doppler Nav", "ASN-41 Destination - Longitude Slew")
 
 --Externals
-A_4E_C:defineIntegerFromGetter("EXT_SPEED_BRAKES", function()
-	return math.floor(LoGetAircraftDrawArgumentValue(500) * 65535)
-end, 65535, "External Aircraft Model", "Speed Brakes")
-A_4E_C:defineIntegerFromGetter("EXT_HOOK", function()
-	return math.floor(LoGetAircraftDrawArgumentValue(25) * 65535)
-end, 65535, "External Aircraft Model", "Hook")
-A_4E_C:defineIntegerFromGetter("EXT_POSITION_LIGHT_LEFT", function()
-	if LoGetAircraftDrawArgumentValue(190) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Left Position Light (red)")
-A_4E_C:defineIntegerFromGetter("EXT_POSITION_LIGHT_RIGHT", function()
-	if LoGetAircraftDrawArgumentValue(191) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Right Position Light (green)")
-A_4E_C:defineIntegerFromGetter("EXT_TAIL_LIGHT", function()
-	if LoGetAircraftDrawArgumentValue(192) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Tail Light (white)")
-A_4E_C:defineIntegerFromGetter("EXT_STROBE_TOP", function()
-	if LoGetAircraftDrawArgumentValue(198) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Top Strobe Light (red)")
-A_4E_C:defineIntegerFromGetter("EXT_STROBE_BOTTOM", function()
-	if LoGetAircraftDrawArgumentValue(199) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Bottom Strobe Light (red)")
-A_4E_C:defineIntegerFromGetter("EXT_TAXI_LIGHT", function()
-	if LoGetAircraftDrawArgumentValue(208) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Taxi Light (white)")
-A_4E_C:defineIntegerFromGetter("EXT_WOW_NOSE", function()
-	if LoGetAircraftDrawArgumentValue(1) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Nose Gear")
-A_4E_C:defineIntegerFromGetter("EXT_WOW_RIGHT", function()
-	if LoGetAircraftDrawArgumentValue(4) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Right Gear")
-A_4E_C:defineIntegerFromGetter("EXT_WOW_LEFT", function()
-	if LoGetAircraftDrawArgumentValue(6) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Left Gear")
+A_4E_C:defineFloatFromDrawArgument("EXT_SPEED_BRAKES", 500, "External Aircraft Model", "Speed Brakes")
+A_4E_C:defineFloatFromDrawArgument("EXT_HOOK", 25, "External Aircraft Model", "Hook")
+A_4E_C:defineBitFromDrawArgument("EXT_POSITION_LIGHT_LEFT", 190, "External Aircraft Model", "Left Position Light (red)")
+A_4E_C:defineBitFromDrawArgument(
+	"EXT_POSITION_LIGHT_RIGHT",
+	191,
+	"External Aircraft Model",
+	"Right Position Light (green)"
+)
+A_4E_C:defineBitFromDrawArgument("EXT_TAIL_LIGHT", 192, "External Aircraft Model", "Tail Light (white)")
+A_4E_C:defineBitFromDrawArgument("EXT_STROBE_TOP", 198, "External Aircraft Model", "Top Strobe Light (red)")
+A_4E_C:defineBitFromDrawArgument("EXT_STROBE_BOTTOM", 199, "External Aircraft Model", "Bottom Strobe Light (red)")
+A_4E_C:defineBitFromDrawArgument("EXT_TAXI_LIGHT", 208, "External Aircraft Model", "Taxi Light (white)")
+A_4E_C:defineBitFromDrawArgument("EXT_WOW_NOSE", 1, "External Aircraft Model", "Weight ON Wheels Nose Gear")
+A_4E_C:defineBitFromDrawArgument("EXT_WOW_RIGHT", 4, "External Aircraft Model", "Weight ON Wheels Right Gear")
+A_4E_C:defineBitFromDrawArgument("EXT_WOW_LEFT", 6, "External Aircraft Model", "Weight ON Wheels Left Gear")
 
 A_4E_C:defineFloat("AFCS_ROLL", 260, { -1, 1 }, "AFCS", "AFCS Roll Gauge")
 A_4E_C:defineFloat("AFCS_YAW", 261, { -1, 1 }, "AFCS", "AFCS Yaw Gauge")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/P-51D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/P-51D.lua
@@ -256,48 +256,27 @@ P_51D:defineFloat("FUEL_TANK_RIGHT", 156, { 0, 1 }, "Fuel System", "Fuel Tank Ri
 P_51D:defineFloat("FUEL_TANK_FUSELAGE", 160, { 0, 1 }, "Fuel System", "Fuel Tank Fuselage")
 
 --Externals
-P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_LEFT", function()
-	if LoGetAircraftDrawArgumentValue(190) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Left Position Light (red)")
-P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_RIGHT", function()
-	if LoGetAircraftDrawArgumentValue(191) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Right Position Light (green)")
-P_51D:defineIntegerFromGetter("EXT_POSITION_LIGHT_TAIL", function()
-	if LoGetAircraftDrawArgumentValue(192) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Tail Position Light (white)")
-P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_RD", function()
-	if LoGetAircraftDrawArgumentValue(200) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Red Recognition Light (red)")
-P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_GN", function()
-	if LoGetAircraftDrawArgumentValue(201) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Green Recognition Light (green)")
-P_51D:defineIntegerFromGetter("EXT_RECOC_LIGHT_YE", function()
-	if LoGetAircraftDrawArgumentValue(202) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Amber Recognition Light (yellow)")
+P_51D:defineBitFromDrawArgument("EXT_POSITION_LIGHT_LEFT", 190, "External Aircraft Model", "Left Position Light (red)")
+P_51D:defineBitFromDrawArgument(
+	"EXT_POSITION_LIGHT_RIGHT",
+	191,
+	"External Aircraft Model",
+	"Right Position Light (green)"
+)
+P_51D:defineBitFromDrawArgument(
+	"EXT_POSITION_LIGHT_TAIL",
+	192,
+	"External Aircraft Model",
+	"Tail Position Light (white)"
+)
+P_51D:defineBitFromDrawArgument("EXT_RECOC_LIGHT_RD", 200, "External Aircraft Model", "Red Recognition Light (red)")
+P_51D:defineBitFromDrawArgument("EXT_RECOC_LIGHT_GN", 201, "External Aircraft Model", "Green Recognition Light (green)")
+P_51D:defineBitFromDrawArgument(
+	"EXT_RECOC_LIGHT_YE",
+	202,
+	"External Aircraft Model",
+	"Amber Recognition Light (yellow)"
+)
 
 --[[--Gauge Values--]]
 --
@@ -430,37 +409,13 @@ P_51D:defineIntegerFromGetter("ACCELEROMETER_VALUE", getAccel, 65000, "Gauge Val
 P_51D:defineIndicatorLight("WINDSHIELD_OIL_L", 412, "Damage", "Windshield Oil Splashes (black)")
 P_51D:defineFloat("WINDSHIELD_CRACKS", 413, { 0, 1 }, "Damage", "Windshield Crack Holes")
 
-P_51D:defineIntegerFromGetter("EXT_WOW_TAIL", function()
-	if LoGetAircraftDrawArgumentValue(1) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Tail Gear")
+P_51D:defineBitFromDrawArgument("EXT_WOW_TAIL", 1, "External Aircraft Model", "Weight ON Wheels Tail Gear")
 
-P_51D:defineIntegerFromGetter("EXT_WOW_RIGHT", function()
-	if LoGetAircraftDrawArgumentValue(4) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Right Gear")
+P_51D:defineBitFromDrawArgument("EXT_WOW_RIGHT", 4, "External Aircraft Model", "Weight ON Wheels Right Gear")
 
-P_51D:defineIntegerFromGetter("EXT_WOW_LEFT", function()
-	if LoGetAircraftDrawArgumentValue(6) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Weight ON Wheels Left Gear")
+P_51D:defineBitFromDrawArgument("EXT_WOW_LEFT", 6, "External Aircraft Model", "Weight ON Wheels Left Gear")
 
-P_51D:defineIntegerFromGetter("EXT_LANDING_LIGHT", function()
-	if LoGetAircraftDrawArgumentValue(208) > 0 then
-		return 1
-	else
-		return 0
-	end
-end, 1, "External Aircraft Model", "Landing Light (white)")
+P_51D:defineBitFromDrawArgument("EXT_LANDING_LIGHT", 208, "External Aircraft Model", "Landing Light (white)")
 
 P_51D:defineFloat("CANOPY_POS", 162, { 0, 1 }, "Cockpit Mechanical", "Canopy Position")
 P_51D:defineRadioWheel(

--- a/Scripts/DCS-BIOS/test/ModuleTest.lua
+++ b/Scripts/DCS-BIOS/test/ModuleTest.lua
@@ -433,33 +433,83 @@ function TestModule:testAddRadioWheel()
 	lu.assertEquals(string_output.address, moduleAddress + 2) -- string will require new address
 end
 
+function TestModule:testAddBitFromDrawArgument()
+	local id = "MY_BIT_DRAW"
+	local draw_arg_id = 1
+	local category = "Bit Draw Arguments"
+	local description = "This is a bit draw argument"
+
+	local control = self.module:defineBitFromDrawArgument(id, draw_arg_id, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.metadata)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 0)
+
+	lu.assertEquals(#control.outputs, 1)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 1)
+	lu.assertEquals(integer_output.suffix, Suffix.none)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
+function TestModule:testAddFloatFromDrawArgument()
+	local id = "MY_FLOAT_DRAW"
+	local draw_arg_id = 1
+	local category = "Float Draw Arguments"
+	local description = "This is a float draw argument"
+
+	local control = self.module:defineFloatFromDrawArgument(id, draw_arg_id, category, description)
+
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.metadata)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
+
+	lu.assertEquals(#control.inputs, 0)
+
+	lu.assertEquals(#control.outputs, 1)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, 65535)
+	lu.assertEquals(integer_output.suffix, Suffix.none)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
+end
+
 function TestModule:testAddIntegerFromGetter()
-	function TestModule:testAddTumbNoCycle()
-		local id = "MY_INT_GETTER"
-		local getter = function(dev0) end
-		local max_value = 255
-		local category = "Integer Getters"
-		local description = "This is an integer getter"
+	local id = "MY_INT_GETTER"
+	local getter = function(dev0) end
+	local max_value = 255
+	local category = "Integer Getters"
+	local description = "This is an integer getter"
 
-		local control = self.module:defineIntegerFromGetter(id, getter, max_value, category, description)
+	local control = self.module:defineIntegerFromGetter(id, getter, max_value, category, description)
 
-		lu.assertEquals(control, self.module.documentation[category][id])
-		lu.assertEquals(control.control_type, ControlType.metadata)
-		lu.assertEquals(control.category, category)
-		lu.assertEquals(control.description, description)
-		lu.assertEquals(control.identifier, id)
-		lu.assertIsNil(control.physical_variant)
-		lu.assertIsNil(control.api_variant)
+	lu.assertEquals(control, self.module.documentation[category][id])
+	lu.assertEquals(control.control_type, ControlType.metadata)
+	lu.assertEquals(control.category, category)
+	lu.assertEquals(control.description, description)
+	lu.assertEquals(control.identifier, id)
+	lu.assertIsNil(control.physical_variant)
+	lu.assertIsNil(control.api_variant)
 
-		lu.assertEquals(#control.inputs, 0)
+	lu.assertEquals(#control.inputs, 0)
 
-		lu.assertEquals(#control.outputs, 1)
-		local integer_output = control.outputs[1] --[[@as IntegerOutput]]
-		lu.assertEquals(integer_output.type, OutputType.integer)
-		lu.assertEquals(integer_output.max_value, max_value)
-		lu.assertEquals(integer_output.suffix, Suffix.none)
-		lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
-	end
+	lu.assertEquals(#control.outputs, 1)
+	local integer_output = control.outputs[1] --[[@as IntegerOutput]]
+	lu.assertEquals(integer_output.type, OutputType.integer)
+	lu.assertEquals(integer_output.max_value, max_value)
+	lu.assertEquals(integer_output.suffix, Suffix.none)
+	lu.assertEquals(integer_output.address, moduleAddress) -- first control, should be plenty of room, no need to move the address
 end
 
 function TestModule:testAddTumbNoCycle()


### PR DESCRIPTION
This cleans up `defineIntegerFromGetter` calls which use functionally identical methods to get data from `LoGetAircraftDrawArgumentValue `.

This cleanup is only done in the newly-migrated modules. Existing modules may be converted on migration.