### PR TITLE
Require tests to pass before running nightly release

### DIFF
--- a/.github/workflows/release-openbeta.yml
+++ b/.github/workflows/release-openbeta.yml
@@ -10,7 +10,25 @@ env:
   RELEASE_FILE_NAME: 'DCS-BIOS_openbeta.zip'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    name: Run unit tests
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up lua
+        uses: leafo/gh-actions-lua@v10
+        with:
+          luaVersion: "5.1.5"
+
+      - name: test
+        run: |
+          lua ./Scripts/DCS-BIOS/test/TestSuite.lua
+
   release:
+    needs: test
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Previously the release would run even if tests would fail. This could be problematic as the tests could fail due to errors that would prevent dcs-bios from working, and as such we should make sure not to release a new nightly build in this case as it would be non-functional.

Github documentation on prerequisite workflow jobs [here](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow#defining-prerequisite-jobs)