### PR TITLE
Adds support for CI workflows to be run as part of merge queue builds

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,9 @@
 name: Validate style
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Run unit tests
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
Some reading about merge queues here https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#about-merge-queues

This will enable the CI workflows to run during merge queue group builds.