### PR TITLE
Functions made class, error gone

### DIFF
--- a/Scripts/DCS-BIOS/BIOS.lua
+++ b/Scripts/DCS-BIOS/BIOS.lua
@@ -35,7 +35,6 @@ BIOS.json = json and json() or require "JSON" -- if that fails, fall back to mod
 
 dofile(lfs.writedir()..[[Scripts/DCS-BIOS/lib/Util.lua]])
 dofile(lfs.writedir()..[[Scripts/DCS-BIOS/lib/Protocol.lua]])
-dofile(lfs.writedir()..[[Scripts/DCS-BIOS/lib/common/Functions.lua]])
 -- dofile(lfs.writedir()..[[Scripts/DCS-BIOS/lib/archive/old_format_planes/MetadataEnd.lua]])
 local MetadataEnd = require "MetadataEnd"
 BIOS.protocol.writeNewModule(MetadataEnd)

--- a/Scripts/DCS-BIOS/lib/common/Functions.lua
+++ b/Scripts/DCS-BIOS/lib/common/Functions.lua
@@ -1,10 +1,21 @@
 module("Functions", package.seeall)
 
+--- @class Functions
 local Functions = {}
+
+--- @func Returns new Functions
+--- @return Functions
+function Functions:new()
+	--- @type Functions
+	local o = {}
+	setmetatable(o, self)
+	self.__index = self
+	return o
+end
 
 --- @func Returns the path of the calling script
 --- @return string
-function Functions.scriptPath()
+function Functions:scriptPath()
 	local str = debug.getinfo(2, "S").source:sub(2)
 	return str:match("(.*/)")
 end
@@ -12,7 +23,7 @@ end
 --- @func Returns value if not nil or an empty string
 --- @param value string?
 --- @return string
-function Functions.coerce_nil_to_string(value)
+function Functions:coerce_nil_to_string(value)
 	return value and value or ""
 end
 
@@ -20,15 +31,15 @@ end
 --- @param str string? The base text
 --- @param len number The length the string should be
 --- @return string result A new string of length len, with whitespace padding added to the left as necessary
-function Functions.padLeft(str, len)
-	str = tostring(Functions.coerce_nil_to_string(str))
+function Functions:pad_left(str, len)
+	str = tostring(self:coerce_nil_to_string(str))
 	return string.rep(" ", len - #str) .. str
 end
 
 --- @func Takes a string and checks for nil, returns 1 or 0
 --- @param str string?
 --- @return integer
-function Functions.nil_state_to_int_flag(str)
+function Functions:nil_state_to_int_flag(str)
 	return str and 1 or 0
 end
 
@@ -36,7 +47,7 @@ end
 --- Please strongly consider using nil_state_to_int_flag instead of this function. This function exists for legacy purposes only.
 --- @param str string?
 --- @return string
-function Functions.nil_state_to_str_flag(str)
+function Functions:nil_state_to_str_flag(str)
 	return str and "1" or "0"
 end
 

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
@@ -11,6 +11,7 @@ local AH_64D = Module:new("AH-64D", 0x8000, { "AH-64D_BLK_II" })
 --v1.2d by WarLord & charliefoxtwo
 
 local TextDisplay = require("TextDisplay")
+local Function = Functions:new()
 
 -- remove Arg# PLT 956; CPG 957
 
@@ -21,7 +22,7 @@ local function parse_ku(indicator_id)
 	if not ku then
 		return ""
 	end
-	return Functions.coerce_nil_to_string(ku.Standby_text)
+	return Function:coerce_nil_to_string(ku.Standby_text)
 end
 
 --MPD Left
@@ -819,36 +820,36 @@ AH_64D:addExportHook(function()
 
 	if is_test_page then
 		cmws_page = "TEST"
-		bit_line_1 = Functions.coerce_nil_to_string(cmws["#42#"])
-		bit_line_2 = Functions.coerce_nil_to_string(cmws["#43#"])
+		bit_line_1 = Function:coerce_nil_to_string(cmws["#42#"])
+		bit_line_2 = Function:coerce_nil_to_string(cmws["#43#"])
 
 		-- these values are all guesses
-		d_light_dim = Functions.nil_state_to_int_flag(cmws["#45#"])
-		r_light_dim = Functions.nil_state_to_int_flag(cmws["#44#"])
-		fwd_left_sector_dim = Functions.nil_state_to_int_flag(cmws["#8#"])
-		aft_left_sector_dim = Functions.nil_state_to_int_flag(cmws["#7#"])
-		aft_right_sector_dim = Functions.nil_state_to_int_flag(cmws["#6#"])
-		fwd_right_sector_dim = Functions.nil_state_to_int_flag(cmws["#9#"])
+		d_light_dim = Function:nil_state_to_int_flag(cmws["#45#"])
+		r_light_dim = Function:nil_state_to_int_flag(cmws["#44#"])
+		fwd_left_sector_dim = Function:nil_state_to_int_flag(cmws["#8#"])
+		aft_left_sector_dim = Function:nil_state_to_int_flag(cmws["#7#"])
+		aft_right_sector_dim = Function:nil_state_to_int_flag(cmws["#6#"])
+		fwd_right_sector_dim = Function:nil_state_to_int_flag(cmws["#9#"])
 	else
 		cmws_page = "MAIN"
-		flare_letter = Functions.coerce_nil_to_string(cmws["#83#"])
-		chaff_letter = Functions.coerce_nil_to_string(cmws["#84#"])
-		flare_count = Functions.coerce_nil_to_string(cmws["#85#"])
-		chaff_count = Functions.coerce_nil_to_string(cmws["#86#"])
-		d_light_bright = Functions.nil_state_to_int_flag(cmws["#88#"])
-		d_light_dim = Functions.nil_state_to_int_flag(cmws["#90#"])
-		r_light_bright = Functions.nil_state_to_int_flag(cmws["#87#"])
-		r_light_dim = Functions.nil_state_to_int_flag(cmws["#89#"])
+		flare_letter = Function:coerce_nil_to_string(cmws["#83#"])
+		chaff_letter = Function:coerce_nil_to_string(cmws["#84#"])
+		flare_count = Function:coerce_nil_to_string(cmws["#85#"])
+		chaff_count = Function:coerce_nil_to_string(cmws["#86#"])
+		d_light_bright = Function:nil_state_to_int_flag(cmws["#88#"])
+		d_light_dim = Function:nil_state_to_int_flag(cmws["#90#"])
+		r_light_bright = Function:nil_state_to_int_flag(cmws["#87#"])
+		r_light_dim = Function:nil_state_to_int_flag(cmws["#89#"])
 
-		fwd_left_sector_brt = Functions.nil_state_to_int_flag(cmws["#8#"])
-		aft_left_sector_brt = Functions.nil_state_to_int_flag(cmws["#7#"])
-		aft_right_sector_brt = Functions.nil_state_to_int_flag(cmws["#6#"])
-		fwd_right_sector_brt = Functions.nil_state_to_int_flag(cmws["#9#"])
+		fwd_left_sector_brt = Function:nil_state_to_int_flag(cmws["#8#"])
+		aft_left_sector_brt = Function:nil_state_to_int_flag(cmws["#7#"])
+		aft_right_sector_brt = Function:nil_state_to_int_flag(cmws["#6#"])
+		fwd_right_sector_brt = Function:nil_state_to_int_flag(cmws["#9#"])
 		-- these values are all guesses
-		fwd_left_sector_dim = Functions.nil_state_to_int_flag(cmws["#49#"])
-		aft_left_sector_dim = Functions.nil_state_to_int_flag(cmws["#48#"])
-		aft_right_sector_dim = Functions.nil_state_to_int_flag(cmws["#47#"])
-		fwd_right_sector_dim = Functions.nil_state_to_int_flag(cmws["#50#"])
+		fwd_left_sector_dim = Function:nil_state_to_int_flag(cmws["#49#"])
+		aft_left_sector_dim = Function:nil_state_to_int_flag(cmws["#48#"])
+		aft_right_sector_dim = Function:nil_state_to_int_flag(cmws["#47#"])
+		fwd_right_sector_dim = Function:nil_state_to_int_flag(cmws["#50#"])
 	end
 end)
 

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Ka-50.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Ka-50.lua
@@ -1,8 +1,9 @@
 module("Ka-50", package.seeall)
 
+local Functions = require("Functions")
+local Function = Functions:new()
 local Control = require("Control")
 local ControlType = require("ControlType")
-local Functions = require("Functions")
 local IntegerOutput = require("IntegerOutput")
 local Module = require("Module")
 local PhysicalVariant = require("PhysicalVariant")
@@ -396,13 +397,13 @@ Ka_50:addExportHook(function()
 	indEKRAN = parse_EKRAN() or {}
 end)
 local function getEKRAN_memory()
-	return Functions.nil_state_to_str_flag(indEKRAN.txt_memory or nil)
+	return Function:nil_state_to_str_flag(indEKRAN.txt_memory or nil)
 end
 local function getEKRAN_queue()
-	return Functions.nil_state_to_str_flag(indEKRAN.txt_queue or nil)
+	return Function:nil_state_to_str_flag(indEKRAN.txt_queue or nil)
 end
 local function getEKRAN_failure()
-	return Functions.nil_state_to_str_flag(indEKRAN.txt_failure or nil)
+	return Function:nil_state_to_str_flag(indEKRAN.txt_failure or nil)
 end
 Ka_50:defineString("EKRAN_MEMORY", getEKRAN_memory, 1, "EKRAN", "Memory message")
 Ka_50:defineString("EKRAN_QUEUE", getEKRAN_queue, 1, "EKRAN", "Queue message")
@@ -413,7 +414,7 @@ Ka_50:defineString("EKRAN_FAILURE", getEKRAN_failure, 1, "EKRAN", "Failure messa
 --- @param index integer
 --- @return string
 local function item_of_nullable_array(arr, index)
-	return Functions.coerce_nil_to_string(arr and arr[index])
+	return Function:coerce_nil_to_string(arr and arr[index])
 end
 
 local function getEKRAN_txt1_line1()


### PR DESCRIPTION
```
aircraft_modules/Ka-50.lua"]:399: attempt to call field 'nil_state_to_str_flag' (a nil value)
stack traceback:
    [C]: in function 'nil_state_to_str_flag'
aircraft_modules/Ka-50.lua"]:399: in function 'getter'
Module.lua"]:481: in function 'v'
Protocol.lua"]:257: in function 'step'
local function getEKRAN_memory()
    return Functions.nil_state_to_str_flag(indEKRAN.txt_memory or nil)
end
local function getEKRAN_queue()
    return Functions.nil_state_to_str_flag(indEKRAN.txt_queue or nil)
end
local function getEKRAN_failure()
    return Functions.nil_state_to_str_flag(indEKRAN.txt_failure or nil)
end
Ka_50:defineString("EKRAN_MEMORY", getEKRAN_memory, 1, "EKRAN", "Memory message")
Ka_50:defineString("EKRAN_QUEUE", getEKRAN_queue, 1, "EKRAN", "Queue message")
Ka_50:defineString("EKRAN_FAILURE", getEKRAN_failure, 1, "EKRAN", "Failure message")
```