### PR TITLE
Consolidate parse_indication logic

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/Module.lua
+++ b/Scripts/DCS-BIOS/lib/modules/Module.lua
@@ -8,6 +8,7 @@ local ControlType = require("ControlType")
 local Documentation = require("Documentation")
 local FixedStepInput = require("FixedStepInput")
 local IntegerOutput = require("IntegerOutput")
+local Log = require("Log")
 local MemoryMap = require("MemoryMap")
 local MomentaryPositions = require("MomentaryPositions")
 local PhysicalVariant = require("PhysicalVariant")
@@ -15,7 +16,6 @@ local SetStateInput = require("SetStateInput")
 local StringOutput = require("StringOutput")
 local Suffix = require("Suffix")
 local VariableStepInput = require("VariableStepInput")
-local json = require("JSONHelper")
 
 --- @class Module
 --- @field name string the name of the module
@@ -860,23 +860,94 @@ function Module:addressDefineIdentifier(identifier)
 	return full_identifier
 end
 
+local indication_split = "-----------------------------------------"
+local children_start_block = "children are {"
+local children_end_block = "}"
+
+--- @enum ParseIndicationState
+local ParseIndicationState = {
+	none = "none",
+	child_block = "child_block",
+	item_block = "item_block",
+}
+
 --- Parses a dcs indication from a string into a key-value table, or nil if no data is available
 --- Values are separated with "-----------------------------------------\n"
 --- @param indicator_id integer
 --- @return {[string]: string}
 function Module.parse_indication(indicator_id)
 	local ret = {}
-	local li = list_indication(indicator_id)
+	local indication = list_indication(indicator_id)
+	--- @type ParseIndicationState[]
+	local state = {}
+	--- @type string?
+	local key = nil
+	--- @type string[]
+	local current_block_lines = {}
 
-	if li ~= "" then
-		local match = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
-		while true do
-			local name, value = match()
-			if not name then
-				break
-			end
-			ret[name] = value
+	---@return ParseIndicationState
+	local function current_state()
+		return #state > 0 and state[#state] or ParseIndicationState.none
+	end
+
+	local function add_block_to_result()
+		if not key then
+			return
 		end
+
+		local value = ""
+		while #current_block_lines > 0 do
+			if value ~= "" then
+				value = value .. "\n"
+			end
+			value = value .. table.remove(current_block_lines, 1)
+		end
+		ret[key] = value -- if there's nothing, then we intentionally add an empty string
+
+		key = nil
+	end
+
+	-- state machine to process indication
+	for line in string.gmatch(indication, "([^\n]+)") do
+		if line == indication_split then
+			-- start a new item block
+			if current_state() ~= ParseIndicationState.item_block then -- don't insert this if we're already in a block - state is already accurate
+				table.insert(state, ParseIndicationState.item_block)
+			else
+				-- write old item and start a new one
+				add_block_to_result()
+			end
+		elseif line == children_start_block then
+			-- start a new child block
+			if current_state() == ParseIndicationState.item_block then
+				table.remove(state)
+			end
+			table.insert(state, ParseIndicationState.child_block)
+			current_block_lines = {}
+			key = nil
+		elseif line == children_end_block and #state > 0 then
+			-- end a child block if we're in one
+			if current_state() == ParseIndicationState.item_block then
+				-- write old item and start a new one
+				add_block_to_result()
+				table.remove(state)
+			end
+			if current_state() == ParseIndicationState.child_block then
+				table.remove(state)
+			end
+		elseif line and current_state() == ParseIndicationState.item_block then
+			-- these are actual line contents we need to deal with
+			if key then
+				table.insert(current_block_lines, line)
+			else
+				key = line
+			end
+		end
+	end
+
+	if current_state() == ParseIndicationState.item_block then
+		add_block_to_result()
+		table.remove(state)
 	end
 
 	return ret

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-14.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-14.lua
@@ -30,139 +30,99 @@ function F_14:defineIndicatorLightLANTBottom(identifier, arg_number, category, d
 	self:defineGatedIndicatorLight(identifier, arg_number, 0.55, 0.99, category, description)
 end
 
-local function getHUD_Mode(dev0)
-	local hud_m = "1"
-	if dev0 ~= nil then
-		if dev0:get_argument_value(1014) == 1 then --Cruise
-			hud_m = "2"
-		elseif dev0:get_argument_value(1013) == 1 then --A2A
-			hud_m = "3"
-		elseif dev0:get_argument_value(1012) == 1 then --A2G
-			hud_m = "4"
-		elseif dev0:get_argument_value(1011) == 1 then --Landing
-			hud_m = "5"
-		end
-	end
-	return hud_m
-end
+local steer_mode = "2"
 
-local function getSTEER_Mode(dev0)
-	local steer_m = "2"
-	if dev0 ~= nil then
-		if dev0:get_argument_value(1002) == 1 then --TACAN
-			steer_m = "1"
-		elseif dev0:get_argument_value(1003) == 1 then --DEST
-			steer_m = "2"
-		elseif dev0:get_argument_value(1004) == 1 then --AWL/PCD
-			steer_m = "3"
-		elseif dev0:get_argument_value(1005) == 1 then --Vector
-			steer_m = "4"
-		elseif dev0:get_argument_value(1006) == 1 then --Manual
-			steer_m = "5"
-		end
-	end
-	return steer_m
-end
+F_14:addExportHook(function(dev0)
+	steer_mode = "2"
 
-local function getAIRSOURCE_Mode(dev0)
-	local airsource_m = "5"
-	if dev0 ~= nil then
-		if dev0:get_argument_value(929) == 1 then --RAM
-			airsource_m = "1"
-		elseif dev0:get_argument_value(930) == 1 then --LEFT
-			airsource_m = "2"
-		elseif dev0:get_argument_value(931) == 1 then --RIGHT
-			airsource_m = "3"
-		elseif dev0:get_argument_value(932) == 1 then --BOTH
-			airsource_m = "4"
-		end
-	end
-	return airsource_m
-end
-
---------------------------------- Matchstick
-local function parse_indication_number_index(indicator_id)
-	-- Custom version of parse_indication function that uses numbers for the index of the output table
-	-- for use in situations where the names of values in the indication are unusable (eg random GUID)
-	-- also adds the number of rows to the table at index 0
-	-- please think carefully before copying this function. In most cases, the standard parse_indication function
-	-- is what you want to call. Util.lua
-	local t = {}
-	local li = list_indication(indicator_id)
-	local m = li:gmatch("-----------------------------------------\n([^\n]+)\n([^\n]*)\n")
-	local counter = 0
-	while true do
-		local name, value = m()
-		counter = counter + 1
-		if not name then
-			break
-		end
-		t[counter] = value
-	end
-	t[0] = counter
-	if t == nil then
-		return
-	end
-	return t
-end
-
-local function get_radio_remote_display(dev0, indicatorId, testButtonId) -- Data from specified device (9=Pilot UHF, 10=RIO UHF, 13=Pilot VHF/UHF)
-	local data = parse_indication_number_index(indicatorId) -- status of relevant test button (ID 15004 = Pilot UHF, 405 = RIO UHF, 15003 = Pilot VHF/UHF)
-	local testPressed = dev0:get_argument_value(testButtonId)
-	local retVal
-
-	if data and data[0] then
-		-- data[0] holds the length of the data table. 7 Indicates it is in manual frequency mode otherwise it is in preset mode.
-		-- testPressed indicates the current value of the specified radio display test button - if pressed we need to return the test value not the current manual or preset frequency.
-		-- depending on the type of data and the test button status assemble the result including separator if necessary.
-		-- 2021/11/23 - Heatblur have changed the order of items in the List Indication for the Pilot Remove Displays but not for the RIO.
-		-- So we now need two different versions of the code depending which display we are requesting.
-		if indicatorId == 10 then
-			if data[0] == 7 and testPressed == 0 then
-				retVal = data[5]:sub(1, 3) .. data[6] .. data[5]:sub(4)
-			elseif data[0] == 7 then
-				retVal = data[3]:sub(1, 3) .. data[4] .. data[3]:sub(4)
-			elseif testPressed == 0 then
-				retVal = data[5]
-			else
-				retVal = data[3]:sub(1, 3) .. data[4] .. data[3]:sub(4)
-			end
-		else
-			if data[0] == 7 and testPressed == 0 then
-				retVal = data[3]:sub(1, 3) .. data[4] .. data[3]:sub(4)
-			elseif data[0] == 7 then
-				retVal = data[5]:sub(1, 3) .. data[6] .. data[5]:sub(4)
-			elseif testPressed == 0 then
-				retVal = data[3]
-			else
-				retVal = data[4]:sub(1, 3) .. data[5] .. data[4]:sub(4)
-			end
-		end
-	end
-	if retVal == nil then
-		return
-	end
-	return retVal
-end
-
-local HSD_TACAN_RANGE = ""
-local HSD_TACAN_CRS = ""
-local HSD_MAN_CRS = ""
-local HSD_TACAN_CRSint = 0
-local HSD_MAN_CRSint = 0
-
-F_14:addExportHook(function()
-	HSDInd = parse_indication_number_index(1)
-	local steerMode = getSTEER_Mode(GetDevice(0))
-	if steerMode == "1" then
-		HSD_TACAN_RANGE = HSDInd[19]
-		HSD_TACAN_CRS = HSDInd[20]
-		HSD_TACAN_CRSint = tonumber(HSD_TACAN_CRS) or 0
-	elseif steerMode == "5" then
-		HSD_MAN_CRS = HSDInd[16]
-		HSD_MAN_CRSint = tonumber(HSD_MAN_CRS) or 0
+	if dev0:get_argument_value(1002) == 1 then --TACAN
+		steer_mode = "1"
+	elseif dev0:get_argument_value(1003) == 1 then --DEST
+		steer_mode = "2"
+	elseif dev0:get_argument_value(1004) == 1 then --AWL/PCD
+		steer_mode = "3"
+	elseif dev0:get_argument_value(1005) == 1 then --Vector
+		steer_mode = "4"
+	elseif dev0:get_argument_value(1006) == 1 then --Manual
+		steer_mode = "5"
 	end
 end)
+
+local hsd_ind = {}
+
+F_14:addExportHook(function(dev0)
+	hsd_ind = Module.parse_indication(1)
+end)
+
+--------------------------------- Matchstick
+
+--- Inserts a separator into the middle of a 6-character radio line
+--- @param line string
+--- @param separator string
+--- @return string
+local function insert_radio_separator(line, separator)
+	if not line or not separator then
+		return ""
+	end
+	return line:sub(1, 3) .. separator .. line:sub(4)
+end
+
+-- 2021/11/23 - Heatblur have changed the order of items in the List Indication for the Pilot Remote Displays but not for the RIO.
+-- So we now need two different versions of the code depending which display we are requesting.
+local function get_rio_uhf_display(dev0)
+	local data = Module.parse_indication(10) -- Data from specified device (9=Pilot UHF, 10=RIO UHF, 13=Pilot VHF/UHF)
+	local test_pressed = dev0:get_argument_value(405) == 1 -- whether test mode is enabled
+
+	if not data[0] then
+		return "0000000"
+	end
+
+	local manual_mode = data[0] == 6
+
+	if manual_mode then
+		if test_pressed then
+			return insert_radio_separator(data[3], data[4])
+		end
+
+		return insert_radio_separator(data[5], data[6])
+	end
+
+	if test_pressed then
+		return insert_radio_separator(data[3], data[4])
+	end
+
+	return insert_radio_separator(data[5], " ")
+end
+
+local function get_radio_remote_display(dev0, indicator_id, test_button_id)
+	local data = Module.parse_indication(indicator_id) -- Data from specified device (9=Pilot UHF, 10=RIO UHF, 13=Pilot VHF/UHF)
+
+	-- testPressed indicates the current value of the specified radio display test button - if pressed we need to return the test value not the current manual or preset frequency.
+	-- depending on the type of data and the test button status assemble the result including separator if necessary.
+	local test_pressed = dev0:get_argument_value(test_button_id) == 1 -- whether test mode is enabled
+
+	if not data[0] then
+		return "0000000"
+	end
+
+	-- data[0] holds the length of the data table. 6 Indicates it is in manual frequency mode otherwise it is in preset mode.
+	local manual_mode = data[0] == 6
+
+	if manual_mode then
+		if test_pressed then
+			return insert_radio_separator(data[5], data[6])
+		end
+
+		return insert_radio_separator(data[3], data[4])
+	end
+
+	if test_pressed then
+		return insert_radio_separator(data[4], data[5])
+	end
+
+	return insert_radio_separator(data[3], " ")
+end
+
 --------------------------------- Matchstick End
 
 ----------------------------------------- BIOS-Profile
@@ -1403,31 +1363,67 @@ F_14:defineFloat("RIO_RECORD_MIN_LOW", 11602, { 0, 1 }, "RIO Gauges", "RIO Recor
 F_14:defineFloat("CANOPY_POS", 403, { 0, 1 }, "Cockpit", "Canopy Position")
 
 F_14:defineString("PLT_UHF_REMOTE_DISP", function(dev0)
-	return get_radio_remote_display(dev0, 9, 15004) or "0000000"
+	return get_radio_remote_display(dev0, 9, 15004)
 end, 7, "UHF 1", "PILOT UHF ARC-159 Radio Remote Display")
 F_14:defineString("RIO_UHF_REMOTE_DISP", function(dev0)
-	return get_radio_remote_display(dev0, 10, 405) or "0000000"
+	return get_rio_uhf_display(dev0)
 end, 7, "UHF 1", "RIO UHF ARC-159 Radio Remote Display")
 F_14:defineString("PLT_VUHF_REMOTE_DISP", function(dev0)
-	return get_radio_remote_display(dev0, 13, 15003) or "0000000"
+	return get_radio_remote_display(dev0, 13, 15003)
 end, 7, "VUHF", "PILOT VHF/UHF ARC-182 Radio Remote Display")
-F_14:defineString("PLT_HUD_MODE", getHUD_Mode, 1, "Display", "PILOT HUD Mode (string)")
-F_14:defineString("PLT_STEER_MODE", getSTEER_Mode, 1, "Display", "PILOT STEER Mode (string)")
-F_14:defineString("PLT_AIR_SOURCE_MODE", getAIRSOURCE_Mode, 1, "Display", "PILOT Air Source Mode (string)")
+
+local function get_hud_mode(dev0)
+	local hud_mode = "1"
+
+	if dev0:get_argument_value(1014) == 1 then --Cruise
+		hud_mode = "2"
+	elseif dev0:get_argument_value(1013) == 1 then --A2A
+		hud_mode = "3"
+	elseif dev0:get_argument_value(1012) == 1 then --A2G
+		hud_mode = "4"
+	elseif dev0:get_argument_value(1011) == 1 then --Landing
+		hud_mode = "5"
+	end
+
+	return hud_mode
+end
+
+F_14:defineString("PLT_HUD_MODE", get_hud_mode, 1, "Display", "PILOT HUD Mode (string)")
+F_14:defineString("PLT_STEER_MODE", function()
+	return steer_mode
+end, 1, "Display", "PILOT STEER Mode (string)")
+
+local function get_airsource_mode(dev0)
+	local airsource_mode = "5"
+
+	if dev0:get_argument_value(929) == 1 then --RAM
+		airsource_mode = "1"
+	elseif dev0:get_argument_value(930) == 1 then --LEFT
+		airsource_mode = "2"
+	elseif dev0:get_argument_value(931) == 1 then --RIGHT
+		airsource_mode = "3"
+	elseif dev0:get_argument_value(932) == 1 then --BOTH
+		airsource_mode = "4"
+	end
+
+	return airsource_mode
+end
+
+F_14:defineString("PLT_AIR_SOURCE_MODE", get_airsource_mode, 1, "Display", "PILOT Air Source Mode (string)")
 F_14:defineString("HSD_TACAN_RANGE_S", function()
-	return HSD_TACAN_RANGE or "00000"
+	return steer_mode == "1" and hsd_ind[16] or "00000"
 end, 5, "HSD", "HSD TACAN Range Display (string)")
 F_14:defineString("HSD_TACAN_CRS_S", function()
-	return HSD_TACAN_CRS or "000"
+	return steer_mode == "1" and hsd_ind[17] or "000"
 end, 3, "HSD", "HSD TACAN Course Display (string)")
 F_14:defineString("HSD_MAN_CRS_S", function()
-	return HSD_MAN_CRS or "000"
+	return steer_mode == "5" and hsd_ind[14] or "000"
 end, 3, "HSD", "HSD MAN Course Display (string)")
 F_14:defineIntegerFromGetter("HSD_TACAN_CRS", function()
-	return HSD_TACAN_CRSint
+	return steer_mode == "1" and tonumber(hsd_ind[17]) or 0
 end, 360, "HSD", "HSD TACAN Course Display")
 F_14:defineIntegerFromGetter("HSD_MAN_CRS", function()
-	return HSD_MAN_CRSint
+	return steer_mode == "5" and tonumber(hsd_ind[14]) or 0
 end, 360, "HSD", "HSD MAN Course Display")
 
 F_14:defineToggleSwitch("PLT_HUDCAM", 12, 3756, 3490, "Cockpit Mechanics", "PILOT Hide Guncam")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Ka-50.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Ka-50.lua
@@ -340,48 +340,27 @@ Ka_50:definePushButton("VOICE_MSG_REPEAT", 13, 3003, 385, "Landing Lights & Voic
 
 ----Right Forward Panel
 --EKRAN Warning System display
----This is an adaptation of parse_indication due to the EKRAN having arrays for some values. In most cases, parse_indication should be used.
-local function parse_EKRAN()
-	local ret = {}
-	local li = list_indication(4)
-	if li == "" then
-		return {}
-	end
 
-	local m = li:gmatch("([^\n]*)\n")
-	local newval = false
-	local name = nil
-	local value = {}
-
-	while true do
-		local line = m()
-		if not line then
-			if name ~= nil then
-				ret[name] = value
-			end
-			break
-		end
-		if line == "-----------------------------------------" then
-			newval = true
-			if name ~= nil then
-				ret[name] = value
-				name = nil
-				value = {}
-			end
-		else
-			if newval == true then
-				newval = false
-				name = line
-			else
-				value[#value + 1] = line
-			end
+--- Splits a string into an array by newlines
+--- @param inputstr string?
+--- @return string[]
+local function line_split(inputstr)
+	local t = {}
+	if inputstr then
+		for str in string.gmatch(inputstr, "([^\n]+)") do
+			table.insert(t, str)
 		end
 	end
-	return ret
+	return t
 end
+
 local indEKRAN = {}
+local ekran_txt_1 = {}
+local ekran_txt_2 = {}
 Ka_50:addExportHook(function()
-	indEKRAN = parse_EKRAN()
+	indEKRAN = Module.parse_indication(4)
+	ekran_txt_1 = line_split(indEKRAN.txt_1)
+	ekran_txt_2 = line_split(indEKRAN.txt_2)
 end)
 local function getEKRAN_memory()
 	return Functions.nil_state_to_str_flag(indEKRAN.txt_memory)
@@ -396,41 +375,33 @@ Ka_50:defineString("EKRAN_MEMORY", getEKRAN_memory, 1, "EKRAN", "Memory message"
 Ka_50:defineString("EKRAN_QUEUE", getEKRAN_queue, 1, "EKRAN", "Queue message")
 Ka_50:defineString("EKRAN_FAILURE", getEKRAN_failure, 1, "EKRAN", "Failure message")
 
---- Returns an item of an array if the array exists, otherwise an empty string
---- @param arr string[]?
---- @param index integer
---- @return string
-local function item_of_nullable_array(arr, index)
-	return Functions.coerce_nil_to_string(arr and arr[index])
-end
-
 local function getEKRAN_txt1_line1()
-	return item_of_nullable_array(indEKRAN.txt_1, 1)
+	return Functions.coerce_nil_to_string(ekran_txt_1[1])
 end
 local function getEKRAN_txt1_line2()
-	return item_of_nullable_array(indEKRAN.txt_1, 2)
+	return Functions.coerce_nil_to_string(ekran_txt_1[2])
 end
 local function getEKRAN_txt1_line3()
-	return item_of_nullable_array(indEKRAN.txt_1, 3)
+	return Functions.coerce_nil_to_string(ekran_txt_1[3])
 end
 local function getEKRAN_txt1_line4()
-	return item_of_nullable_array(indEKRAN.txt_1, 4)
+	return Functions.coerce_nil_to_string(ekran_txt_1[4])
 end
 Ka_50:defineString("EKRAN_TXT1_LINE1", getEKRAN_txt1_line1, 10, "EKRAN", "EKRAN txt 1 line 1")
 Ka_50:defineString("EKRAN_TXT1_LINE2", getEKRAN_txt1_line2, 10, "EKRAN", "EKRAN txt 1 line 2")
 Ka_50:defineString("EKRAN_TXT1_LINE3", getEKRAN_txt1_line3, 10, "EKRAN", "EKRAN txt 1 line 3")
 Ka_50:defineString("EKRAN_TXT1_LINE4", getEKRAN_txt1_line4, 10, "EKRAN", "EKRAN txt 1 line 4")
 local function getEKRAN_txt2_line1()
-	return item_of_nullable_array(indEKRAN.txt_2, 1)
+	return Functions.coerce_nil_to_string(ekran_txt_2[1])
 end
 local function getEKRAN_txt2_line2()
-	return item_of_nullable_array(indEKRAN.txt_2, 2)
+	return Functions.coerce_nil_to_string(ekran_txt_2[2])
 end
 local function getEKRAN_txt2_line3()
-	return item_of_nullable_array(indEKRAN.txt_2, 3)
+	return Functions.coerce_nil_to_string(ekran_txt_2[3])
 end
 local function getEKRAN_txt2_line4()
-	return item_of_nullable_array(indEKRAN.txt_2, 4)
+	return Functions.coerce_nil_to_string(ekran_txt_2[4])
 end
 Ka_50:defineString("EKRAN_TXT2_LINE1", getEKRAN_txt2_line1, 10, "EKRAN", "EKRAN txt 2 line 1")
 Ka_50:defineString("EKRAN_TXT2_LINE2", getEKRAN_txt2_line2, 10, "EKRAN", "EKRAN txt 2 line 2")

--- a/Scripts/DCS-BIOS/test/ParseIndicationTest.lua
+++ b/Scripts/DCS-BIOS/test/ParseIndicationTest.lua
@@ -62,7 +62,7 @@ txt_NIT_apostrophe2
 	lu.assertEquals(ind.txt_NIT_apostrophe2, "'")
 end
 
-function TestParseIndication:test_multiline()
+function TestParseIndication:testMultiline()
 	-- KA-50 indication 4
 	local test_string = [[-----------------------------------------
 frame
@@ -94,7 +94,7 @@ txt_2
 	lu.assertEquals(ind.txt_2, txt_2_expected)
 end
 
-function TestParseIndication:test_multiple_children()
+function TestParseIndication:testMultipleChildren()
 	--- A-10 indication 3
 	local test_string = [[-----------------------------------------
 LowerLeftCornerCDU
@@ -241,4 +241,116 @@ ScratchBorders
 	lu.assertEquals(ind.DTSAS_EGI_STATUS, "**/B1")
 	lu.assertEquals(ind.NUM, " ")
 	lu.assertEquals(ind.ScratchBorders, "[               ]")
+end
+
+function TestParseIndication:testNumericIndex()
+	local test_string = [[-----------------------------------------
+HSD_base
+
+-----------------------------------------
+{5AF8AEA0-CC0E-4150-B4BC-189706D25839}
+
+children are {
+-----------------------------------------
+{91B1C268-6AEA-4b1c-95EA-6C0494D687ED}
+
+-----------------------------------------
+{B69CF7EF-AB8F-465b-950F-C9C55641ED2C}
+
+-----------------------------------------
+{82559090-9105-4542-B174-F795C0138E9D}
+
+-----------------------------------------
+hsd_course_arrow
+
+-----------------------------------------
+{A6C8641F-6002-4616-98EE-AE938AED4916}
+
+-----------------------------------------
+{C75E2B82-EE8F-4ad0-9982-5C50638C2CF4}
+
+}
+-----------------------------------------
+{2FEE4390-94D2-4e2a-928C-EB3BF03B087A}
+
+children are {
+-----------------------------------------
+{9BD5610E-7905-4634-B5CF-30487E17812F}
+
+}
+-----------------------------------------
+{4A8D4200-7E70-4fb2-8724-480882B675EB}
+
+children are {
+-----------------------------------------
+{3011992F-E5A7-483f-A102-D055835E8FE6}
+
+-----------------------------------------
+{5415E8B0-BEC2-4502-AC63-7187A11A2348}
+
+-----------------------------------------
+{78BC989C-1CAE-4b5b-B3FE-5D051A16DCBC}
+031. 
+}
+-----------------------------------------
+{C5A1BA54-45DC-4891-8B46-C96178FCAF61}
+
+children are {
+-----------------------------------------
+{DE81570C-E1F4-4f36-BB3C-332C589F7DF7}
+
+-----------------------------------------
+{DBCB667A-2EE1-4f44-92DA-A4755DD8D840}
+
+-----------------------------------------
+{9206BFC8-D2E2-4ab5-A20E-362BD190E0A6}
+000
+-----------------------------------------
+{0FC85384-6428-4aac-83D1-5FAFD1335635}
+000
+-----------------------------------------
+{91599891-47E1-4d50-BC5F-E9271994BF78}
+
+-----------------------------------------
+{A49AB977-2B32-48ab-A76D-559CE7625BF0}
+
+-----------------------------------------
+tas_string
+0000
+-----------------------------------------
+{A34C1A1E-8DCD-476a-9C67-17CC5468831C}
+0000
+}
+]]
+
+	function list_indication()
+		return test_string
+	end
+
+	local ind = Module.parse_indication(0)
+
+	lu.assertEquals(ind[0], 23)
+	lu.assertEquals(ind[1], "")
+	lu.assertEquals(ind[2], "")
+	lu.assertEquals(ind[3], "")
+	lu.assertEquals(ind[4], "")
+	lu.assertEquals(ind[5], "")
+	lu.assertEquals(ind[6], "")
+	lu.assertEquals(ind[7], "")
+	lu.assertEquals(ind[8], "")
+	lu.assertEquals(ind[9], "")
+	lu.assertEquals(ind[10], "")
+	lu.assertEquals(ind[11], "")
+	lu.assertEquals(ind[12], "")
+	lu.assertEquals(ind[13], "")
+	lu.assertEquals(ind[14], "031. ")
+	lu.assertEquals(ind[15], "")
+	lu.assertEquals(ind[16], "")
+	lu.assertEquals(ind[17], "")
+	lu.assertEquals(ind[18], "000")
+	lu.assertEquals(ind[19], "000")
+	lu.assertEquals(ind[20], "")
+	lu.assertEquals(ind[21], "")
+	lu.assertEquals(ind[22], "0000")
+	lu.assertEquals(ind[23], "0000")
 end

--- a/Scripts/DCS-BIOS/test/ParseIndicationTest.lua
+++ b/Scripts/DCS-BIOS/test/ParseIndicationTest.lua
@@ -1,0 +1,244 @@
+local Module = require("Module")
+local lu = require("luaunit")
+
+--- @class TestParseIndication
+TestParseIndication = {}
+
+function TestParseIndication:testSingleFieldIndication()
+	-- KA-50 indication 7
+	local test_string = [[-----------------------------------------
+txt_digits
+064
+]]
+	function list_indication()
+		return test_string
+	end
+
+	local ind = Module.parse_indication(0)
+	lu.assertEquals(ind.txt_digits, "064")
+end
+
+function TestParseIndication:testMultipleFieldIndication()
+	-- KA-50 indication 5
+	local test_string = [[-----------------------------------------
+#1#
+
+children are {
+-----------------------------------------
+txt_VIT
+ 43116
+-----------------------------------------
+txt_VIT_apostrophe1
+'
+-----------------------------------------
+txt_VIT_apostrophe2
+'
+-----------------------------------------
+txt_OIT_PPM
+1
+-----------------------------------------
+txt_NIT
+044402
+-----------------------------------------
+txt_NIT_apostrophe1
+'
+-----------------------------------------
+txt_NIT_apostrophe2
+'
+}
+]]
+
+	function list_indication()
+		return test_string
+	end
+
+	local ind = Module.parse_indication(0)
+	lu.assertEquals(ind.txt_VIT, " 43116")
+	lu.assertEquals(ind.txt_VIT_apostrophe1, "'")
+	lu.assertEquals(ind.txt_VIT_apostrophe2, "'")
+	lu.assertEquals(ind.txt_OIT_PPM, "1")
+	lu.assertEquals(ind.txt_NIT, "044402")
+	lu.assertEquals(ind.txt_NIT_apostrophe1, "'")
+	lu.assertEquals(ind.txt_NIT_apostrophe2, "'")
+end
+
+function TestParseIndication:test_multiline()
+	-- KA-50 indication 4
+	local test_string = [[-----------------------------------------
+frame
+
+-----------------------------------------
+txt_1
+
+-----------------------------------------
+txt_2
+ДАВЛЕНИЕ 0
+  МАСЛА  1
+         1
+ ЛЕВ РЕД 4
+]]
+
+	function list_indication()
+		return test_string
+	end
+
+	local ind = Module.parse_indication(0)
+
+	local txt_2_expected = [[ДАВЛЕНИЕ 0
+  МАСЛА  1
+         1
+ ЛЕВ РЕД 4]]
+
+	lu.assertEquals(ind.frame, "")
+	lu.assertEquals(ind.txt_1, "")
+	lu.assertEquals(ind.txt_2, txt_2_expected)
+end
+
+function TestParseIndication:test_multiple_children()
+	--- A-10 indication 3
+	local test_string = [[-----------------------------------------
+LowerLeftCornerCDU
+
+children are {
+-----------------------------------------
+PageNameWAYPT
+WAYPT
+-----------------------------------------
+PAGE
+P /2
+}
+-----------------------------------------
+LowerLeftCornerCDU
+
+children are {
+-----------------------------------------
+WAYPT_INCR_DECR
+я
+-----------------------------------------
+WAYPTNumber1
+0
+-----------------------------------------
+STEERPTIndicator
+SP
+-----------------------------------------
+BRACKETS_EL
+
+-----------------------------------------
+EL
+EL:
+-----------------------------------------
+WAYPT_EL3
+67
+-----------------------------------------
+BRACKETS_WPT_NAME
+
+-----------------------------------------
+WAYPTIdent1
+INIT POSIT
+-----------------------------------------
+WAYPTClass21
+UNK
+-----------------------------------------
+DTOT
+DTOT
+-----------------------------------------
+WAYPT_DTOT
+********
+-----------------------------------------
+TGTSYM_NEW_WPT
+©
+-----------------------------------------
+NEW_WAYPT_NUM
+?6
+-----------------------------------------
+WND
+WND    /
+-----------------------------------------
+WAYPTWindDirection1
+***
+-----------------------------------------
+WAYPTWindSpeed1
+***
+-----------------------------------------
+WAYPTCoordFormat
+L/L
+-----------------------------------------
+WAYPTDATA_ENTRY
+
+-----------------------------------------
+WAYPTLat
+N41°55.938
+-----------------------------------------
+WAYPTDATA_ENTRY1
+
+-----------------------------------------
+WAYPTLong
+E041°52.564
+-----------------------------------------
+PAGE_NUM
+1
+}
+-----------------------------------------
+LowerLeftCornerCDU
+
+children are {
+-----------------------------------------
+CurrSteerPointNumber
+0
+-----------------------------------------
+DTSAS_EGI_STATUS
+**/B1
+}
+-----------------------------------------
+LowerLeftCornerCDU
+
+children are {
+-----------------------------------------
+NUM
+ 
+}
+-----------------------------------------
+LowerLeftCornerCDU
+
+children are {
+-----------------------------------------
+ScratchBorders
+[               ]
+}
+]]
+
+	function list_indication()
+		return test_string
+	end
+
+	local ind = Module.parse_indication(0)
+
+	lu.assertEquals(ind.PageNameWAYPT, "WAYPT")
+	lu.assertEquals(ind.PAGE, "P /2")
+	lu.assertEquals(ind.WAYPT_INCR_DECR, "я")
+	lu.assertEquals(ind.WAYPTNumber1, "0")
+	lu.assertEquals(ind.STEERPTIndicator, "SP")
+	lu.assertEquals(ind.BRACKETS_EL, "")
+	lu.assertEquals(ind.EL, "EL:")
+	lu.assertEquals(ind.WAYPT_EL3, "67")
+	lu.assertEquals(ind.BRACKETS_WPT_NAME, "")
+	lu.assertEquals(ind.WAYPTIdent1, "INIT POSIT")
+	lu.assertEquals(ind.WAYPTClass21, "UNK")
+	lu.assertEquals(ind.DTOT, "DTOT")
+	lu.assertEquals(ind.WAYPT_DTOT, "********")
+	lu.assertEquals(ind.TGTSYM_NEW_WPT, "©")
+	lu.assertEquals(ind.NEW_WAYPT_NUM, "?6")
+	lu.assertEquals(ind.WND, "WND    /")
+	lu.assertEquals(ind.WAYPTWindDirection1, "***")
+	lu.assertEquals(ind.WAYPTWindSpeed1, "***")
+	lu.assertEquals(ind.WAYPTCoordFormat, "L/L")
+	lu.assertEquals(ind.WAYPTDATA_ENTRY, "")
+	lu.assertEquals(ind.WAYPTLat, "N41°55.938")
+	lu.assertEquals(ind.WAYPTDATA_ENTRY1, "")
+	lu.assertEquals(ind.WAYPTLong, "E041°52.564")
+	lu.assertEquals(ind.PAGE_NUM, "1")
+	lu.assertEquals(ind.CurrSteerPointNumber, "0")
+	lu.assertEquals(ind.DTSAS_EGI_STATUS, "**/B1")
+	lu.assertEquals(ind.NUM, " ")
+	lu.assertEquals(ind.ScratchBorders, "[               ]")
+end

--- a/Scripts/DCS-BIOS/test/TestSuite.lua
+++ b/Scripts/DCS-BIOS/test/TestSuite.lua
@@ -25,6 +25,7 @@ require("AircraftTest") -- high-level tests for specific aircraft
 require("MemoryMapTest") -- unit tests for the memory map
 require("MemoryMapEntryTest") -- unit tests for memory map entries
 require("ModuleTest") -- unit tests for core aircraft module functionality
+require("ParseIndicationTest") -- unit tests for the parse_indication function
 require("ProtocolIOTest") -- unit tests for send/receive logic
 require("ServerTest") -- unit tests for tcp/udp server code
 


### PR DESCRIPTION
Consolidates the KA-50 and F-14's custom parse_indication logic into the standard parse_indication so other modules may take advantage of this behavior in the future if needed. This also cleans up some logic around parse_indication usage in each module.

Furthermore, this adds tests for parse_indication which use real export data from various aircraft.