### PR TITLE
#383 Migrate some broken Mosquito controls off of define3PosMossi

### DIFF
--- a/Scripts/DCS-BIOS/doc/json/Mosquito.json
+++ b/Scripts/DCS-BIOS/doc/json/Mosquito.json
@@ -1852,27 +1852,29 @@
                                },
                  "Main Panel": {
                                               "AILERON_TRIM": {
-                                                                      "category": "Main Panel",
-                                                                  "control_type": "selector",
-                                                                   "description": "Aileron Trim",
-                                                                    "identifier": "AILERON_TRIM",
-                                                                        "inputs": [ {
-                                                                                      "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                        "interface": "set_state",
-                                                                                        "max_value": 2
-                                                                                  } ],
-                                                                       "outputs": [ {
-                                                                                                            "address": 28696,
-                                                                                                 "address_identifier": "Mosquito_AILERON_TRIM_A",
-                                                                                            "address_mask_identifier": "Mosquito_AILERON_TRIM_AM",
-                                                                                      "address_mask_shift_identifier": "Mosquito_AILERON_TRIM",
-                                                                                                        "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                               "mask": 12288,
-                                                                                                          "max_value": 2,
-                                                                                                           "shift_by": 12,
-                                                                                                             "suffix": "",
-                                                                                                               "type": "integer"
-                                                                                  } ]
+                                                                             "category": "Main Panel",
+                                                                         "control_type": "selector",
+                                                                          "description": "Aileron Trim",
+                                                                           "identifier": "AILERON_TRIM",
+                                                                               "inputs": [ {
+                                                                                             "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                               "interface": "set_state",
+                                                                                               "max_value": 2
+                                                                                         } ],
+                                                                  "momentary_positions": "first_and_last",
+                                                                              "outputs": [ {
+                                                                                                                   "address": 28696,
+                                                                                                        "address_identifier": "Mosquito_AILERON_TRIM_A",
+                                                                                                   "address_mask_identifier": "Mosquito_AILERON_TRIM_AM",
+                                                                                             "address_mask_shift_identifier": "Mosquito_AILERON_TRIM",
+                                                                                                               "description": "selector position",
+                                                                                                                      "mask": 12288,
+                                                                                                                 "max_value": 2,
+                                                                                                                  "shift_by": 12,
+                                                                                                                    "suffix": "",
+                                                                                                                      "type": "integer"
+                                                                                         } ],
+                                                                     "physical_variant": "rocker_switch"
                                                               },
                                                    "ALT_SET": {
                                                                    "api_variant": "multiturn",
@@ -2682,27 +2684,29 @@
                                                                                   } ]
                                                               },
                                                "RUDDER_TRIM": {
-                                                                      "category": "Main Panel",
-                                                                  "control_type": "selector",
-                                                                   "description": "Rudder Trim",
-                                                                    "identifier": "RUDDER_TRIM",
-                                                                        "inputs": [ {
-                                                                                      "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                        "interface": "set_state",
-                                                                                        "max_value": 2
-                                                                                  } ],
-                                                                       "outputs": [ {
-                                                                                                            "address": 28696,
-                                                                                                 "address_identifier": "Mosquito_RUDDER_TRIM_A",
-                                                                                            "address_mask_identifier": "Mosquito_RUDDER_TRIM_AM",
-                                                                                      "address_mask_shift_identifier": "Mosquito_RUDDER_TRIM",
-                                                                                                        "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                               "mask": 3072,
-                                                                                                          "max_value": 2,
-                                                                                                           "shift_by": 10,
-                                                                                                             "suffix": "",
-                                                                                                               "type": "integer"
-                                                                                  } ]
+                                                                             "category": "Main Panel",
+                                                                         "control_type": "selector",
+                                                                          "description": "Rudder Trim",
+                                                                           "identifier": "RUDDER_TRIM",
+                                                                               "inputs": [ {
+                                                                                             "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                               "interface": "set_state",
+                                                                                               "max_value": 2
+                                                                                         } ],
+                                                                  "momentary_positions": "first_and_last",
+                                                                              "outputs": [ {
+                                                                                                                   "address": 28696,
+                                                                                                        "address_identifier": "Mosquito_RUDDER_TRIM_A",
+                                                                                                   "address_mask_identifier": "Mosquito_RUDDER_TRIM_AM",
+                                                                                             "address_mask_shift_identifier": "Mosquito_RUDDER_TRIM",
+                                                                                                               "description": "selector position",
+                                                                                                                      "mask": 3072,
+                                                                                                                 "max_value": 2,
+                                                                                                                  "shift_by": 10,
+                                                                                                                    "suffix": "",
+                                                                                                                      "type": "integer"
+                                                                                         } ],
+                                                                     "physical_variant": "rocker_switch"
                                                               },
                                             "STBD_LAND_L_SW": {
                                                                              "category": "Main Panel",
@@ -3955,27 +3959,29 @@
                                                                           } ]
                                                       },
                                      "ELEVATOR_TRIM": {
-                                                              "category": "Port Wall",
-                                                          "control_type": "selector",
-                                                           "description": "Elevator Trim",
-                                                            "identifier": "ELEVATOR_TRIM",
-                                                                "inputs": [ {
-                                                                              "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                "interface": "set_state",
-                                                                                "max_value": 2
-                                                                          } ],
-                                                               "outputs": [ {
-                                                                                                    "address": 28806,
-                                                                                         "address_identifier": "Mosquito_ELEVATOR_TRIM_A",
-                                                                                    "address_mask_identifier": "Mosquito_ELEVATOR_TRIM_AM",
-                                                                              "address_mask_shift_identifier": "Mosquito_ELEVATOR_TRIM",
-                                                                                                "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                       "mask": 96,
-                                                                                                  "max_value": 2,
-                                                                                                   "shift_by": 5,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                          } ]
+                                                                     "category": "Port Wall",
+                                                                 "control_type": "selector",
+                                                                  "description": "Elevator Trim",
+                                                                   "identifier": "ELEVATOR_TRIM",
+                                                                       "inputs": [ {
+                                                                                     "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                       "interface": "set_state",
+                                                                                       "max_value": 2
+                                                                                 } ],
+                                                          "momentary_positions": "first_and_last",
+                                                                      "outputs": [ {
+                                                                                                           "address": 28806,
+                                                                                                "address_identifier": "Mosquito_ELEVATOR_TRIM_A",
+                                                                                           "address_mask_identifier": "Mosquito_ELEVATOR_TRIM_AM",
+                                                                                     "address_mask_shift_identifier": "Mosquito_ELEVATOR_TRIM",
+                                                                                                       "description": "selector position",
+                                                                                                              "mask": 96,
+                                                                                                         "max_value": 2,
+                                                                                                          "shift_by": 5,
+                                                                                                            "suffix": "",
+                                                                                                              "type": "integer"
+                                                                                 } ],
+                                                             "physical_variant": "rocker_switch"
                                                       },
                                        "EMERG_L_DIM": {
                                                               "category": "Port Wall",
@@ -4633,27 +4639,29 @@
                                },
                       "R1155": {
                                    "R1155_AURAL_SENSE": {
-                                                                "category": "R1155",
-                                                            "control_type": "selector",
-                                                             "description": "R.1155 Aural Sense Switch",
-                                                              "identifier": "R1155_AURAL_SENSE",
-                                                                  "inputs": [ {
-                                                                                "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                  "interface": "set_state",
-                                                                                  "max_value": 2
-                                                                            } ],
-                                                                 "outputs": [ {
-                                                                                                      "address": 28874,
-                                                                                           "address_identifier": "Mosquito_R1155_AURAL_SENSE_A",
-                                                                                      "address_mask_identifier": "Mosquito_R1155_AURAL_SENSE_AM",
-                                                                                "address_mask_shift_identifier": "Mosquito_R1155_AURAL_SENSE",
-                                                                                                  "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                         "mask": 6144,
-                                                                                                    "max_value": 2,
-                                                                                                     "shift_by": 11,
-                                                                                                       "suffix": "",
-                                                                                                         "type": "integer"
-                                                                            } ]
+                                                                       "category": "R1155",
+                                                                   "control_type": "selector",
+                                                                    "description": "R.1155 Aural Sense Switch",
+                                                                     "identifier": "R1155_AURAL_SENSE",
+                                                                         "inputs": [ {
+                                                                                       "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                         "interface": "set_state",
+                                                                                         "max_value": 2
+                                                                                   } ],
+                                                            "momentary_positions": "first_and_last",
+                                                                        "outputs": [ {
+                                                                                                             "address": 28874,
+                                                                                                  "address_identifier": "Mosquito_R1155_AURAL_SENSE_A",
+                                                                                             "address_mask_identifier": "Mosquito_R1155_AURAL_SENSE_AM",
+                                                                                       "address_mask_shift_identifier": "Mosquito_R1155_AURAL_SENSE",
+                                                                                                         "description": "selector position",
+                                                                                                                "mask": 6144,
+                                                                                                           "max_value": 2,
+                                                                                                            "shift_by": 11,
+                                                                                                              "suffix": "",
+                                                                                                                "type": "integer"
+                                                                                   } ],
+                                                               "physical_variant": "rocker_switch"
                                                         },
                                         "R1155_FILTER": {
                                                                        "category": "R1155",
@@ -5603,27 +5611,29 @@
                                                                 "physical_variant": "push_button"
                                                          },
                                          "AERIAL_WINCH": {
-                                                                 "category": "Starboard Wall",
-                                                             "control_type": "selector",
-                                                              "description": "Aerial Winch Rotary Handle",
-                                                               "identifier": "AERIAL_WINCH",
-                                                                   "inputs": [ {
-                                                                                 "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                   "interface": "set_state",
-                                                                                   "max_value": 2
-                                                                             } ],
-                                                                  "outputs": [ {
-                                                                                                       "address": 28842,
-                                                                                            "address_identifier": "Mosquito_AERIAL_WINCH_A",
-                                                                                       "address_mask_identifier": "Mosquito_AERIAL_WINCH_AM",
-                                                                                 "address_mask_shift_identifier": "Mosquito_AERIAL_WINCH",
-                                                                                                   "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                          "mask": 192,
-                                                                                                     "max_value": 2,
-                                                                                                      "shift_by": 6,
-                                                                                                        "suffix": "",
-                                                                                                          "type": "integer"
-                                                                             } ]
+                                                                        "category": "Starboard Wall",
+                                                                    "control_type": "selector",
+                                                                     "description": "Aerial Winch Rotary Handle",
+                                                                      "identifier": "AERIAL_WINCH",
+                                                                          "inputs": [ {
+                                                                                        "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 2
+                                                                                    } ],
+                                                             "momentary_positions": "first_and_last",
+                                                                         "outputs": [ {
+                                                                                                              "address": 28842,
+                                                                                                   "address_identifier": "Mosquito_AERIAL_WINCH_A",
+                                                                                              "address_mask_identifier": "Mosquito_AERIAL_WINCH_AM",
+                                                                                        "address_mask_shift_identifier": "Mosquito_AERIAL_WINCH",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 192,
+                                                                                                            "max_value": 2,
+                                                                                                             "shift_by": 6,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "rocker_switch"
                                                          },
                                            "CAM_GUN_SW": {
                                                                         "category": "Starboard Wall",

--- a/Scripts/DCS-BIOS/doc/json/Mosquito.jsonp
+++ b/Scripts/DCS-BIOS/doc/json/Mosquito.jsonp
@@ -1853,27 +1853,29 @@ docdata["Mosquito"] =
                                },
                  "Main Panel": {
                                               "AILERON_TRIM": {
-                                                                      "category": "Main Panel",
-                                                                  "control_type": "selector",
-                                                                   "description": "Aileron Trim",
-                                                                    "identifier": "AILERON_TRIM",
-                                                                        "inputs": [ {
-                                                                                      "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                        "interface": "set_state",
-                                                                                        "max_value": 2
-                                                                                  } ],
-                                                                       "outputs": [ {
-                                                                                                            "address": 28696,
-                                                                                                 "address_identifier": "Mosquito_AILERON_TRIM_A",
-                                                                                            "address_mask_identifier": "Mosquito_AILERON_TRIM_AM",
-                                                                                      "address_mask_shift_identifier": "Mosquito_AILERON_TRIM",
-                                                                                                        "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                               "mask": 12288,
-                                                                                                          "max_value": 2,
-                                                                                                           "shift_by": 12,
-                                                                                                             "suffix": "",
-                                                                                                               "type": "integer"
-                                                                                  } ]
+                                                                             "category": "Main Panel",
+                                                                         "control_type": "selector",
+                                                                          "description": "Aileron Trim",
+                                                                           "identifier": "AILERON_TRIM",
+                                                                               "inputs": [ {
+                                                                                             "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                               "interface": "set_state",
+                                                                                               "max_value": 2
+                                                                                         } ],
+                                                                  "momentary_positions": "first_and_last",
+                                                                              "outputs": [ {
+                                                                                                                   "address": 28696,
+                                                                                                        "address_identifier": "Mosquito_AILERON_TRIM_A",
+                                                                                                   "address_mask_identifier": "Mosquito_AILERON_TRIM_AM",
+                                                                                             "address_mask_shift_identifier": "Mosquito_AILERON_TRIM",
+                                                                                                               "description": "selector position",
+                                                                                                                      "mask": 12288,
+                                                                                                                 "max_value": 2,
+                                                                                                                  "shift_by": 12,
+                                                                                                                    "suffix": "",
+                                                                                                                      "type": "integer"
+                                                                                         } ],
+                                                                     "physical_variant": "rocker_switch"
                                                               },
                                                    "ALT_SET": {
                                                                    "api_variant": "multiturn",
@@ -2683,27 +2685,29 @@ docdata["Mosquito"] =
                                                                                   } ]
                                                               },
                                                "RUDDER_TRIM": {
-                                                                      "category": "Main Panel",
-                                                                  "control_type": "selector",
-                                                                   "description": "Rudder Trim",
-                                                                    "identifier": "RUDDER_TRIM",
-                                                                        "inputs": [ {
-                                                                                      "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                        "interface": "set_state",
-                                                                                        "max_value": 2
-                                                                                  } ],
-                                                                       "outputs": [ {
-                                                                                                            "address": 28696,
-                                                                                                 "address_identifier": "Mosquito_RUDDER_TRIM_A",
-                                                                                            "address_mask_identifier": "Mosquito_RUDDER_TRIM_AM",
-                                                                                      "address_mask_shift_identifier": "Mosquito_RUDDER_TRIM",
-                                                                                                        "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                               "mask": 3072,
-                                                                                                          "max_value": 2,
-                                                                                                           "shift_by": 10,
-                                                                                                             "suffix": "",
-                                                                                                               "type": "integer"
-                                                                                  } ]
+                                                                             "category": "Main Panel",
+                                                                         "control_type": "selector",
+                                                                          "description": "Rudder Trim",
+                                                                           "identifier": "RUDDER_TRIM",
+                                                                               "inputs": [ {
+                                                                                             "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                               "interface": "set_state",
+                                                                                               "max_value": 2
+                                                                                         } ],
+                                                                  "momentary_positions": "first_and_last",
+                                                                              "outputs": [ {
+                                                                                                                   "address": 28696,
+                                                                                                        "address_identifier": "Mosquito_RUDDER_TRIM_A",
+                                                                                                   "address_mask_identifier": "Mosquito_RUDDER_TRIM_AM",
+                                                                                             "address_mask_shift_identifier": "Mosquito_RUDDER_TRIM",
+                                                                                                               "description": "selector position",
+                                                                                                                      "mask": 3072,
+                                                                                                                 "max_value": 2,
+                                                                                                                  "shift_by": 10,
+                                                                                                                    "suffix": "",
+                                                                                                                      "type": "integer"
+                                                                                         } ],
+                                                                     "physical_variant": "rocker_switch"
                                                               },
                                             "STBD_LAND_L_SW": {
                                                                              "category": "Main Panel",
@@ -3956,27 +3960,29 @@ docdata["Mosquito"] =
                                                                           } ]
                                                       },
                                      "ELEVATOR_TRIM": {
-                                                              "category": "Port Wall",
-                                                          "control_type": "selector",
-                                                           "description": "Elevator Trim",
-                                                            "identifier": "ELEVATOR_TRIM",
-                                                                "inputs": [ {
-                                                                              "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                "interface": "set_state",
-                                                                                "max_value": 2
-                                                                          } ],
-                                                               "outputs": [ {
-                                                                                                    "address": 28806,
-                                                                                         "address_identifier": "Mosquito_ELEVATOR_TRIM_A",
-                                                                                    "address_mask_identifier": "Mosquito_ELEVATOR_TRIM_AM",
-                                                                              "address_mask_shift_identifier": "Mosquito_ELEVATOR_TRIM",
-                                                                                                "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                       "mask": 96,
-                                                                                                  "max_value": 2,
-                                                                                                   "shift_by": 5,
-                                                                                                     "suffix": "",
-                                                                                                       "type": "integer"
-                                                                          } ]
+                                                                     "category": "Port Wall",
+                                                                 "control_type": "selector",
+                                                                  "description": "Elevator Trim",
+                                                                   "identifier": "ELEVATOR_TRIM",
+                                                                       "inputs": [ {
+                                                                                     "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                       "interface": "set_state",
+                                                                                       "max_value": 2
+                                                                                 } ],
+                                                          "momentary_positions": "first_and_last",
+                                                                      "outputs": [ {
+                                                                                                           "address": 28806,
+                                                                                                "address_identifier": "Mosquito_ELEVATOR_TRIM_A",
+                                                                                           "address_mask_identifier": "Mosquito_ELEVATOR_TRIM_AM",
+                                                                                     "address_mask_shift_identifier": "Mosquito_ELEVATOR_TRIM",
+                                                                                                       "description": "selector position",
+                                                                                                              "mask": 96,
+                                                                                                         "max_value": 2,
+                                                                                                          "shift_by": 5,
+                                                                                                            "suffix": "",
+                                                                                                              "type": "integer"
+                                                                                 } ],
+                                                             "physical_variant": "rocker_switch"
                                                       },
                                        "EMERG_L_DIM": {
                                                               "category": "Port Wall",
@@ -4634,27 +4640,29 @@ docdata["Mosquito"] =
                                },
                       "R1155": {
                                    "R1155_AURAL_SENSE": {
-                                                                "category": "R1155",
-                                                            "control_type": "selector",
-                                                             "description": "R.1155 Aural Sense Switch",
-                                                              "identifier": "R1155_AURAL_SENSE",
-                                                                  "inputs": [ {
-                                                                                "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                  "interface": "set_state",
-                                                                                  "max_value": 2
-                                                                            } ],
-                                                                 "outputs": [ {
-                                                                                                      "address": 28874,
-                                                                                           "address_identifier": "Mosquito_R1155_AURAL_SENSE_A",
-                                                                                      "address_mask_identifier": "Mosquito_R1155_AURAL_SENSE_AM",
-                                                                                "address_mask_shift_identifier": "Mosquito_R1155_AURAL_SENSE",
-                                                                                                  "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                         "mask": 6144,
-                                                                                                    "max_value": 2,
-                                                                                                     "shift_by": 11,
-                                                                                                       "suffix": "",
-                                                                                                         "type": "integer"
-                                                                            } ]
+                                                                       "category": "R1155",
+                                                                   "control_type": "selector",
+                                                                    "description": "R.1155 Aural Sense Switch",
+                                                                     "identifier": "R1155_AURAL_SENSE",
+                                                                         "inputs": [ {
+                                                                                       "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                         "interface": "set_state",
+                                                                                         "max_value": 2
+                                                                                   } ],
+                                                            "momentary_positions": "first_and_last",
+                                                                        "outputs": [ {
+                                                                                                             "address": 28874,
+                                                                                                  "address_identifier": "Mosquito_R1155_AURAL_SENSE_A",
+                                                                                             "address_mask_identifier": "Mosquito_R1155_AURAL_SENSE_AM",
+                                                                                       "address_mask_shift_identifier": "Mosquito_R1155_AURAL_SENSE",
+                                                                                                         "description": "selector position",
+                                                                                                                "mask": 6144,
+                                                                                                           "max_value": 2,
+                                                                                                            "shift_by": 11,
+                                                                                                              "suffix": "",
+                                                                                                                "type": "integer"
+                                                                                   } ],
+                                                               "physical_variant": "rocker_switch"
                                                         },
                                         "R1155_FILTER": {
                                                                        "category": "R1155",
@@ -5604,27 +5612,29 @@ docdata["Mosquito"] =
                                                                 "physical_variant": "push_button"
                                                          },
                                          "AERIAL_WINCH": {
-                                                                 "category": "Starboard Wall",
-                                                             "control_type": "selector",
-                                                              "description": "Aerial Winch Rotary Handle",
-                                                               "identifier": "AERIAL_WINCH",
-                                                                   "inputs": [ {
-                                                                                 "description": "set the switch position -- 0 = left, 1 = centered, 2 = right",
-                                                                                   "interface": "set_state",
-                                                                                   "max_value": 2
-                                                                             } ],
-                                                                  "outputs": [ {
-                                                                                                       "address": 28842,
-                                                                                            "address_identifier": "Mosquito_AERIAL_WINCH_A",
-                                                                                       "address_mask_identifier": "Mosquito_AERIAL_WINCH_AM",
-                                                                                 "address_mask_shift_identifier": "Mosquito_AERIAL_WINCH",
-                                                                                                   "description": "selector position -- 0 = Left, 1 = Mid ,  2 = Right",
-                                                                                                          "mask": 192,
-                                                                                                     "max_value": 2,
-                                                                                                      "shift_by": 6,
-                                                                                                        "suffix": "",
-                                                                                                          "type": "integer"
-                                                                             } ]
+                                                                        "category": "Starboard Wall",
+                                                                    "control_type": "selector",
+                                                                     "description": "Aerial Winch Rotary Handle",
+                                                                      "identifier": "AERIAL_WINCH",
+                                                                          "inputs": [ {
+                                                                                        "description": "set the switch position -- 0 = held left/down, 1 = centered, 2 = held right/up",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 2
+                                                                                    } ],
+                                                             "momentary_positions": "first_and_last",
+                                                                         "outputs": [ {
+                                                                                                              "address": 28842,
+                                                                                                   "address_identifier": "Mosquito_AERIAL_WINCH_A",
+                                                                                              "address_mask_identifier": "Mosquito_AERIAL_WINCH_AM",
+                                                                                        "address_mask_shift_identifier": "Mosquito_AERIAL_WINCH",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 192,
+                                                                                                            "max_value": 2,
+                                                                                                             "shift_by": 6,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "rocker_switch"
                                                          },
                                            "CAM_GUN_SW": {
                                                                         "category": "Starboard Wall",

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Mosquito.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/Mosquito.lua
@@ -67,6 +67,18 @@ function Mosquito:define3PosMossi(msg, device_id, command, arg_number, category,
 	end)
 end
 
+--- Adds a 3-position rocker switch that only uses a single command
+--- @param identifier string the unique identifier for the control
+--- @param device_id integer the dcs device id
+--- @param command integer the dcs command
+--- @param arg_number integer the dcs argument number
+--- @param category string the category in which the control should appear
+--- @param description string additional information about the control
+--- @return Control control the control which was added to the module
+function Mosquito:defineRockerSwitchMossi(identifier, device_id, command, arg_number, category, description)
+	return self:defineRockerSwitch(identifier, device_id, command, command, command, command, arg_number, category, description)
+end
+
 --Main Pit
 Mosquito:definePushButton("STICK_BTN_A", 5, 3005, 245, "Stick", "Stick Button A - MG Trigger")
 Mosquito:definePushButton("STICK_BTN_B1", 5, 3006, 246, "Stick", "Stick Button B1 - Cannon Trigger")
@@ -122,8 +134,8 @@ Mosquito:defineToggleSwitch("FLAPS_GATE", 17, 3006, 119, "Main Panel", "Flaps Le
 Mosquito:defineToggleSwitch("GUN_MASTER_CVR", 5, 3001, 120, "Main Panel", "Gun Firing Master Switch Cover")
 Mosquito:defineTumb("GUN_MASTER", 5, 3003, 121, 2, { -1, 1 }, nil, false, "Main Panel", "Gun Firing Master Switch")
 Mosquito:defineToggleSwitch("DE_ICE_PUMP", 23, 3001, 370, "Main Panel", "De-Ice Glycol Pump Handle")
-Mosquito:define3PosMossi("RUDDER_TRIM", 2, 3053, 111, "Main Panel", "Rudder Trim")
-Mosquito:define3PosMossi("AILERON_TRIM", 2, 3051, 280, "Main Panel", "Aileron Trim")
+Mosquito:defineRockerSwitchMossi("RUDDER_TRIM", 2, 3053, 111, "Main Panel", "Rudder Trim")
+Mosquito:defineRockerSwitchMossi("AILERON_TRIM", 2, 3051, 280, "Main Panel", "Aileron Trim")
 Mosquito:definePotentiometer("BOMB_PANEL_L_DIM", 4, 3059, 16, { 0, 1 }, "Main Panel", "Bomb Panel Flood Dimmer")
 Mosquito:defineToggleSwitch("BOMB_DOOR_L_CVR", 2, 3067, 284, "Main Panel", "Bomb Door Light Cover")
 Mosquito:defineToggleSwitch("JETT_CONT_CVR", 5, 3056, 144, "Main Panel", "Container Jettison Cover")
@@ -210,7 +222,7 @@ Mosquito:defineToggleSwitch("REP_COMPASS_SW1", 4, 3001, 1, "Port Wall", "R.I. Co
 Mosquito:defineToggleSwitch("REP_COMPASS_SW2", 4, 3002, 2, "Port Wall", "R.I. Compass De-ground Switch")
 Mosquito:defineToggleSwitch("BEAM_SW", 4, 3004, 3, "Port Wall", "Beam Approach Switch")
 Mosquito:defineToggleSwitch("SCR_PTT", 24, 3099, 4, "Port Wall", "SCR-522 PTT Button")
-Mosquito:define3PosMossi("ELEVATOR_TRIM", 2, 3016, 279, "Port Wall", "Elevator Trim")
+Mosquito:defineRockerSwitchMossi("ELEVATOR_TRIM", 2, 3016, 279, "Port Wall", "Elevator Trim")
 
 Mosquito:defineIndicatorLight("UV_L_L", 325, "Port Wall Lights", "Left UV Light (multi)")
 Mosquito:defineIndicatorLight("UV_R_L", 326, "Port Wall Lights", "Right UV Light (multi)")
@@ -274,7 +286,7 @@ Mosquito:defineToggleSwitch("OXY_H_PRESS_VALVE", 2, 3055, 293, "Starboard Wall",
 Mosquito:defineToggleSwitch("STBD_OXY_VALVE", 16, 3003, 187, "Starboard Wall", "Oxygen Regulator Starboard")
 Mosquito:definePotentiometer("CHART_L_DIM", 4, 3095, 303, { 0, 1 }, "Port Wall", "Chart Table Flood Light Dimmer")
 Mosquito:defineToggleSwitch("AERIAL_BRAKE", 31, 3001, 202, "Starboard Wall", "Aerial Winch  Brake Lever")
-Mosquito:define3PosMossi("AERIAL_WINCH", 31, 3004, 356, "Starboard Wall", "Aerial Winch Rotary Handle")
+Mosquito:defineRockerSwitchMossi("AERIAL_WINCH", 31, 3004, 356, "Starboard Wall", "Aerial Winch Rotary Handle")
 Mosquito:definePushButton("AERIAL_REEL", 31, 3005, 357, "Starboard Wall", "Aerial Winch Reel Lock")
 Mosquito:defineToggleSwitch("TRANS_TYPF_SW", 4, 3113, 307, "Starboard Wall", "Transmitter TypeF Switch")
 Mosquito:defineToggleSwitch("LT_T1154_PW", 28, 3001, 305, "Starboard Wall", "T.1154 R.1155 L.T. Power Unit Switch")
@@ -356,7 +368,7 @@ Mosquito:definePotentiometer("R1155_METER_BAL", 25, 3079, 225, { -1, 1 }, "R1155
 Mosquito:defineToggleSwitch("R1155_FILTER", 25, 3082, 226, "R1155", "R.1155 Filter Switch")
 Mosquito:definePotentiometer("R1155_METER_AMP", 25, 3084, 227, { 0, 1 }, "R1155", "R.1155 Meter Amplitude Knob")
 Mosquito:defineToggleSwitch("R1155_METER_DEF", 25, 3087, 235, "R1155", "R.1155 Meter Deflection Sensitivity Switch")
-Mosquito:define3PosMossi("R1155_AURAL_SENSE", 25, 3089, 236, "R1155", "R.1155 Aural Sense Switch")
+Mosquito:defineRockerSwitchMossi("R1155_AURAL_SENSE", 25, 3089, 236, "R1155", "R.1155 Aural Sense Switch")
 Mosquito:defineToggleSwitch("R1155_SW_SPEED", 25, 3090, 237, "R1155", "R.1155 Meter Frequency Switch")
 
 Mosquito:defineFloat("R1155_TUNER_G", 232, { 0, 1 }, "R1155 Gauges", "R.1155 Tuner Gauge")


### PR DESCRIPTION
Fixes the issues with:
- `RUDDER_TRIM`
- `AILERON_TRIM
- `ELEVATOR_TRIM`
- `AERIAL_WINCH`
- `R1155_AURAL_SENSE`