### PR TITLE
Remove LoGetModelTime from BIOSStateMachine constructor

### DIFF
--- a/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
+++ b/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
@@ -35,7 +35,7 @@ function BIOSStateMachine:new(modules_by_name, metadata_start, metadata_end, max
 		update_counter = 0,
 		update_skip_counter = 0,
 		next_step_time = 0,
-		last_frame_time = LoGetModelTime(),
+		last_frame_time = 0,
 	}
 	setmetatable(o, self)
 	self.__index = self

--- a/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
+++ b/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
@@ -8,12 +8,6 @@ package.path = "./Scripts/DCS-BIOS/test/compile/?.lua;" .. package.path
 package.path = "./Scripts/DCS-BIOS/test/ext/?.lua;" .. package.path
 package.path = "./Scripts/DCS-BIOS/test/io/?.lua;" .. package.path
 
---- Returns the simulation time
---- @return number
-function LoGetModelTime()
-	return 0
-end
-
 lfs = require("lfs")
 
 -- Include these that will mock the DCS APIs and the socket.

--- a/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
+++ b/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
@@ -7,7 +7,6 @@
 package.path = "./Scripts/DCS-BIOS/test/compile/?.lua;" .. package.path
 package.path = "./Scripts/DCS-BIOS/test/ext/?.lua;" .. package.path
 
-
 lfs = require("Scripts.DCS-BIOS.test.compile.lfs")
 
 -- Include these that will mock the DCS APIs and the socket.


### PR DESCRIPTION
It isn't actually needed there, and removing it reduces dependence on globals