### PR TITLE
Move JSON.lua to main source code

### DIFF
--- a/.styluaignore
+++ b/.styluaignore
@@ -15,5 +15,7 @@
 !Scripts/DCS-BIOS/lib/common
 # opt-in test code
 !/Scripts/DCS-BIOS/test
+# opt-out external library code
+/Scripts/DCS-BIOS/lib/ext
 # opt-out copy-pasted test library code
 /Scripts/DCS-BIOS/test/ext

--- a/Scripts/DCS-BIOS/lib/common/JSONHelper.lua
+++ b/Scripts/DCS-BIOS/lib/common/JSONHelper.lua
@@ -1,7 +1,6 @@
 module("JSONHelper", package.seeall)
 
-local json = loadfile([[Scripts/JSON.lua]]) -- try to load json from dcs
-local JSON = json and json() or require("JSON") -- if that fails, fall back to module that we can define
+local JSON = require("Scripts.DCS-BIOS.lib.ext.JSON")
 
 --- @class JSONHelper
 local JSONHelper = {}

--- a/Scripts/DCS-BIOS/lib/ext/JSON.lua
+++ b/Scripts/DCS-BIOS/lib/ext/JSON.lua
@@ -1,3 +1,5 @@
+module("JSON", package.seeall)
+
 -- -*- coding: utf-8 -*-
 --
 -- Copyright 2010-2012 Jeffrey Friedl

--- a/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
+++ b/Scripts/DCS-BIOS/test/compile/LocalCompile.lua
@@ -5,7 +5,6 @@
 -- Execute => lua LocalCompile-lua or run it via VS Code task
 
 package.path = "./Scripts/DCS-BIOS/test/compile/?.lua;" .. package.path
-package.path = "./Scripts/DCS-BIOS/test/ext/?.lua;" .. package.path
 
 lfs = require("Scripts.DCS-BIOS.test.compile.lfs")
 


### PR DESCRIPTION
This allows us to run the same code regardless of the environment we're running in. This file is still excluded from stylua as it is an external library.