### PR TITLE
Indent log_table max depth reached message

### DIFF
--- a/Scripts/DCS-BIOS/lib/common/Logger.lua
+++ b/Scripts/DCS-BIOS/lib/common/Logger.lua
@@ -171,7 +171,7 @@ function Logger:dump_table(tab, max_depth)
 		local return_buffer = ""
 
 		if depth > max_depth then
-			local str = "Depth reached in log_table() : " .. max_depth
+			local str = string.rep("\t", max_depth) .. "Depth reached in log_table() : " .. max_depth
 			self.bytes_logged = self.bytes_logged + string.len(str)
 			return_buffer = return_buffer .. "\n" .. str
 			-- This doesn't mean the recursion should stop, just that the current excursion stops


### PR DESCRIPTION
This indents the max depth reached message to be in line with the rest of the log messages at that depth, which makes the logs more easily collapsible in certain text editors.