### PR TITLE
Fix Apache not generating JSON files

### DIFF
--- a/Scripts/DCS-BIOS/doc/doc_assets/AH-64D.jsonp
+++ b/Scripts/DCS-BIOS/doc/doc_assets/AH-64D.jsonp
@@ -1004,6 +1004,63 @@ docdata["AH-64D"] =
                                                                                                                  "type": "integer"
                                                                                     } ],
                                                                 "physical_variant": "toggle_switch"
+                                                         },
+                                       "CPG_WIPER_P_SW": {
+                                                                        "category": "CPG Cockpit",
+                                                                    "control_type": "selector",
+                                                                     "description": "Gunner Wiper Control Switch, PARK",
+                                                                      "identifier": "CPG_WIPER_P_SW",
+                                                                          "inputs": [ {
+                                                                                        "description": "switch to previous or next state",
+                                                                                          "interface": "fixed_step"
+                                                                                    }, {
+                                                                                        "description": "set position",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 1
+                                                                                    }, {
+                                                                                           "argument": "TOGGLE",
+                                                                                        "description": "Toggle switch state",
+                                                                                          "interface": "action"
+                                                                                    } ],
+                                                             "momentary_positions": "none",
+                                                                         "outputs": [ {
+                                                                                                              "address": 34636,
+                                                                                              "address_mask_identifier": "AH_64D_CPG_WIPER_P_SW_AM",
+                                                                                        "address_mask_shift_identifier": "AH_64D_CPG_WIPER_P_SW",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 8192,
+                                                                                                            "max_value": 1,
+                                                                                                             "shift_by": 13,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "toggle_switch"
+                                                         },
+                                         "CPG_WIPER_SW": {
+                                                                        "category": "CPG Cockpit",
+                                                                    "control_type": "selector",
+                                                                     "description": "Gunner Wiper Control Switch, PARK/OFF/LO/HI",
+                                                                      "identifier": "CPG_WIPER_SW",
+                                                                          "inputs": [ {
+                                                                                        "description": "switch to previous or next state",
+                                                                                          "interface": "fixed_step"
+                                                                                    }, {
+                                                                                        "description": "set position",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 2
+                                                                                    } ],
+                                                             "momentary_positions": "none",
+                                                                         "outputs": [ {
+                                                                                                              "address": 34568,
+                                                                                        "address_mask_shift_identifier": "AH_64D_CPG_WIPER_SW",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 49152,
+                                                                                                            "max_value": 2,
+                                                                                                             "shift_by": 14,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "limited_rotary"
                                                          }
                                  },
           "CPG Emergency Panel": {
@@ -6174,32 +6231,6 @@ docdata["AH-64D"] =
                                                                                                                 "type": "integer"
                                                                                    } ],
                                                                "physical_variant": "push_button"
-                                                        },
-                                        "CPG_WIPER_SW": {
-                                                                       "category": "CPG MPD Right",
-                                                                   "control_type": "selector",
-                                                                    "description": "Gunner Wiper Control Switch, PARK/OFF/LO/HI",
-                                                                     "identifier": "CPG_WIPER_SW",
-                                                                         "inputs": [ {
-                                                                                       "description": "switch to previous or next state",
-                                                                                         "interface": "fixed_step"
-                                                                                   }, {
-                                                                                       "description": "set position",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 3
-                                                                                   } ],
-                                                            "momentary_positions": "none",
-                                                                        "outputs": [ {
-                                                                                                             "address": 34568,
-                                                                                       "address_mask_shift_identifier": "AH_64D_CPG_WIPER_SW",
-                                                                                                         "description": "selector position",
-                                                                                                                "mask": 49152,
-                                                                                                           "max_value": 3,
-                                                                                                            "shift_by": 14,
-                                                                                                              "suffix": "",
-                                                                                                                "type": "integer"
-                                                                                   } ],
-                                                               "physical_variant": "limited_rotary"
                                                         }
                                  },
                 "CPG NVS Panel": {
@@ -9043,35 +9074,25 @@ docdata["AH-64D"] =
                                                                                      } ]
                                                                  },
                                                   "PLT_CMWS_PW": {
-                                                                                "category": "PLT CMWS",
-                                                                            "control_type": "selector",
-                                                                             "description": "Pilot CMWS PWR Switch, OFF/ON",
-                                                                              "identifier": "PLT_CMWS_PW",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                                      "address": 34578,
-                                                                                                      "address_mask_identifier": "AH_64D_PLT_CMWS_PW_AM",
-                                                                                                "address_mask_shift_identifier": "AH_64D_PLT_CMWS_PW",
-                                                                                                                  "description": "selector position",
-                                                                                                                         "mask": 8,
-                                                                                                                    "max_value": 1,
-                                                                                                                     "shift_by": 3,
-                                                                                                                       "suffix": "",
-                                                                                                                         "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "limited_rotary"
+                                                                         "category": "PLT CMWS",
+                                                                     "control_type": "3Pos_2Command_Switch_OpenClose",
+                                                                      "description": "Pilot CMWS PWR Switch, OFF/ON/TEST",
+                                                                       "identifier": "PLT_CMWS_PW",
+                                                                           "inputs": [ {
+                                                                                         "description": "set the switch position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 2
+                                                                                     } ],
+                                                                          "outputs": [ {
+                                                                                                               "address": 34636,
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_CMWS_PW",
+                                                                                                           "description": "switch position -- 0 = Down, 1 = Mid,  2 = Up",
+                                                                                                                  "mask": 49152,
+                                                                                                             "max_value": 2,
+                                                                                                              "shift_by": 14,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ]
                                                                  },
                                              "PLT_CMWS_PW_TEST": {
                                                                              "api_variant": "momentary_last_position",
@@ -10169,6 +10190,63 @@ docdata["AH-64D"] =
                                                                                                                   "type": "integer"
                                                                                      } ],
                                                                  "physical_variant": "toggle_switch"
+                                                          },
+                                        "PLT_WIPER_P_SW": {
+                                                                         "category": "PLT Cockpit",
+                                                                     "control_type": "selector",
+                                                                      "description": "Pilot Wiper Control Switch, PARK",
+                                                                       "identifier": "PLT_WIPER_P_SW",
+                                                                           "inputs": [ {
+                                                                                         "description": "switch to previous or next state",
+                                                                                           "interface": "fixed_step"
+                                                                                     }, {
+                                                                                         "description": "set position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 1
+                                                                                     }, {
+                                                                                            "argument": "TOGGLE",
+                                                                                         "description": "Toggle switch state",
+                                                                                           "interface": "action"
+                                                                                     } ],
+                                                              "momentary_positions": "none",
+                                                                          "outputs": [ {
+                                                                                                               "address": 34636,
+                                                                                               "address_mask_identifier": "AH_64D_PLT_WIPER_P_SW_AM",
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_WIPER_P_SW",
+                                                                                                           "description": "selector position",
+                                                                                                                  "mask": 4096,
+                                                                                                             "max_value": 1,
+                                                                                                              "shift_by": 12,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ],
+                                                                 "physical_variant": "toggle_switch"
+                                                          },
+                                          "PLT_WIPER_SW": {
+                                                                         "category": "PLT Cockpit",
+                                                                     "control_type": "selector",
+                                                                      "description": "Pilot Wiper Control Switch, PARK/OFF/LO/HI",
+                                                                       "identifier": "PLT_WIPER_SW",
+                                                                           "inputs": [ {
+                                                                                         "description": "switch to previous or next state",
+                                                                                           "interface": "fixed_step"
+                                                                                     }, {
+                                                                                         "description": "set position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 2
+                                                                                     } ],
+                                                              "momentary_positions": "none",
+                                                                          "outputs": [ {
+                                                                                                               "address": 34568,
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_WIPER_SW",
+                                                                                                           "description": "selector position",
+                                                                                                                  "mask": 96,
+                                                                                                             "max_value": 2,
+                                                                                                              "shift_by": 5,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ],
+                                                                 "physical_variant": "limited_rotary"
                                                           }
                                  },
           "PLT Emergency Panel": {
@@ -15670,32 +15748,6 @@ docdata["AH-64D"] =
                                                                                                                 "type": "integer"
                                                                                    } ],
                                                                "physical_variant": "push_button"
-                                                        },
-                                        "PLT_WIPER_SW": {
-                                                                       "category": "PLT MPD Right",
-                                                                   "control_type": "selector",
-                                                                    "description": "Pilot Wiper Control Switch, PARK/OFF/LO/HI",
-                                                                     "identifier": "PLT_WIPER_SW",
-                                                                         "inputs": [ {
-                                                                                       "description": "switch to previous or next state",
-                                                                                         "interface": "fixed_step"
-                                                                                   }, {
-                                                                                       "description": "set position",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 3
-                                                                                   } ],
-                                                            "momentary_positions": "none",
-                                                                        "outputs": [ {
-                                                                                                             "address": 34568,
-                                                                                       "address_mask_shift_identifier": "AH_64D_PLT_WIPER_SW",
-                                                                                                         "description": "selector position",
-                                                                                                                "mask": 96,
-                                                                                                           "max_value": 3,
-                                                                                                            "shift_by": 5,
-                                                                                                              "suffix": "",
-                                                                                                                "type": "integer"
-                                                                                   } ],
-                                                               "physical_variant": "limited_rotary"
                                                         }
                                  },
                 "PLT NVS Panel": {

--- a/Scripts/DCS-BIOS/doc/json/AH-64D.json
+++ b/Scripts/DCS-BIOS/doc/json/AH-64D.json
@@ -1003,6 +1003,63 @@
                                                                                                                  "type": "integer"
                                                                                     } ],
                                                                 "physical_variant": "toggle_switch"
+                                                         },
+                                       "CPG_WIPER_P_SW": {
+                                                                        "category": "CPG Cockpit",
+                                                                    "control_type": "selector",
+                                                                     "description": "Gunner Wiper Control Switch, PARK",
+                                                                      "identifier": "CPG_WIPER_P_SW",
+                                                                          "inputs": [ {
+                                                                                        "description": "switch to previous or next state",
+                                                                                          "interface": "fixed_step"
+                                                                                    }, {
+                                                                                        "description": "set position",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 1
+                                                                                    }, {
+                                                                                           "argument": "TOGGLE",
+                                                                                        "description": "Toggle switch state",
+                                                                                          "interface": "action"
+                                                                                    } ],
+                                                             "momentary_positions": "none",
+                                                                         "outputs": [ {
+                                                                                                              "address": 34636,
+                                                                                              "address_mask_identifier": "AH_64D_CPG_WIPER_P_SW_AM",
+                                                                                        "address_mask_shift_identifier": "AH_64D_CPG_WIPER_P_SW",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 8192,
+                                                                                                            "max_value": 1,
+                                                                                                             "shift_by": 13,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "toggle_switch"
+                                                         },
+                                         "CPG_WIPER_SW": {
+                                                                        "category": "CPG Cockpit",
+                                                                    "control_type": "selector",
+                                                                     "description": "Gunner Wiper Control Switch, PARK/OFF/LO/HI",
+                                                                      "identifier": "CPG_WIPER_SW",
+                                                                          "inputs": [ {
+                                                                                        "description": "switch to previous or next state",
+                                                                                          "interface": "fixed_step"
+                                                                                    }, {
+                                                                                        "description": "set position",
+                                                                                          "interface": "set_state",
+                                                                                          "max_value": 2
+                                                                                    } ],
+                                                             "momentary_positions": "none",
+                                                                         "outputs": [ {
+                                                                                                              "address": 34568,
+                                                                                        "address_mask_shift_identifier": "AH_64D_CPG_WIPER_SW",
+                                                                                                          "description": "selector position",
+                                                                                                                 "mask": 49152,
+                                                                                                            "max_value": 2,
+                                                                                                             "shift_by": 14,
+                                                                                                               "suffix": "",
+                                                                                                                 "type": "integer"
+                                                                                    } ],
+                                                                "physical_variant": "limited_rotary"
                                                          }
                                  },
           "CPG Emergency Panel": {
@@ -6173,32 +6230,6 @@
                                                                                                                 "type": "integer"
                                                                                    } ],
                                                                "physical_variant": "push_button"
-                                                        },
-                                        "CPG_WIPER_SW": {
-                                                                       "category": "CPG MPD Right",
-                                                                   "control_type": "selector",
-                                                                    "description": "Gunner Wiper Control Switch, PARK/OFF/LO/HI",
-                                                                     "identifier": "CPG_WIPER_SW",
-                                                                         "inputs": [ {
-                                                                                       "description": "switch to previous or next state",
-                                                                                         "interface": "fixed_step"
-                                                                                   }, {
-                                                                                       "description": "set position",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 3
-                                                                                   } ],
-                                                            "momentary_positions": "none",
-                                                                        "outputs": [ {
-                                                                                                             "address": 34568,
-                                                                                       "address_mask_shift_identifier": "AH_64D_CPG_WIPER_SW",
-                                                                                                         "description": "selector position",
-                                                                                                                "mask": 49152,
-                                                                                                           "max_value": 3,
-                                                                                                            "shift_by": 14,
-                                                                                                              "suffix": "",
-                                                                                                                "type": "integer"
-                                                                                   } ],
-                                                               "physical_variant": "limited_rotary"
                                                         }
                                  },
                 "CPG NVS Panel": {
@@ -9042,35 +9073,25 @@
                                                                                      } ]
                                                                  },
                                                   "PLT_CMWS_PW": {
-                                                                                "category": "PLT CMWS",
-                                                                            "control_type": "selector",
-                                                                             "description": "Pilot CMWS PWR Switch, OFF/ON",
-                                                                              "identifier": "PLT_CMWS_PW",
-                                                                                  "inputs": [ {
-                                                                                                "description": "switch to previous or next state",
-                                                                                                  "interface": "fixed_step"
-                                                                                            }, {
-                                                                                                "description": "set position",
-                                                                                                  "interface": "set_state",
-                                                                                                  "max_value": 1
-                                                                                            }, {
-                                                                                                   "argument": "TOGGLE",
-                                                                                                "description": "Toggle switch state",
-                                                                                                  "interface": "action"
-                                                                                            } ],
-                                                                     "momentary_positions": "none",
-                                                                                 "outputs": [ {
-                                                                                                                      "address": 34578,
-                                                                                                      "address_mask_identifier": "AH_64D_PLT_CMWS_PW_AM",
-                                                                                                "address_mask_shift_identifier": "AH_64D_PLT_CMWS_PW",
-                                                                                                                  "description": "selector position",
-                                                                                                                         "mask": 8,
-                                                                                                                    "max_value": 1,
-                                                                                                                     "shift_by": 3,
-                                                                                                                       "suffix": "",
-                                                                                                                         "type": "integer"
-                                                                                            } ],
-                                                                        "physical_variant": "limited_rotary"
+                                                                         "category": "PLT CMWS",
+                                                                     "control_type": "3Pos_2Command_Switch_OpenClose",
+                                                                      "description": "Pilot CMWS PWR Switch, OFF/ON/TEST",
+                                                                       "identifier": "PLT_CMWS_PW",
+                                                                           "inputs": [ {
+                                                                                         "description": "set the switch position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 2
+                                                                                     } ],
+                                                                          "outputs": [ {
+                                                                                                               "address": 34636,
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_CMWS_PW",
+                                                                                                           "description": "switch position -- 0 = Down, 1 = Mid,  2 = Up",
+                                                                                                                  "mask": 49152,
+                                                                                                             "max_value": 2,
+                                                                                                              "shift_by": 14,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ]
                                                                  },
                                              "PLT_CMWS_PW_TEST": {
                                                                              "api_variant": "momentary_last_position",
@@ -10168,6 +10189,63 @@
                                                                                                                   "type": "integer"
                                                                                      } ],
                                                                  "physical_variant": "toggle_switch"
+                                                          },
+                                        "PLT_WIPER_P_SW": {
+                                                                         "category": "PLT Cockpit",
+                                                                     "control_type": "selector",
+                                                                      "description": "Pilot Wiper Control Switch, PARK",
+                                                                       "identifier": "PLT_WIPER_P_SW",
+                                                                           "inputs": [ {
+                                                                                         "description": "switch to previous or next state",
+                                                                                           "interface": "fixed_step"
+                                                                                     }, {
+                                                                                         "description": "set position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 1
+                                                                                     }, {
+                                                                                            "argument": "TOGGLE",
+                                                                                         "description": "Toggle switch state",
+                                                                                           "interface": "action"
+                                                                                     } ],
+                                                              "momentary_positions": "none",
+                                                                          "outputs": [ {
+                                                                                                               "address": 34636,
+                                                                                               "address_mask_identifier": "AH_64D_PLT_WIPER_P_SW_AM",
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_WIPER_P_SW",
+                                                                                                           "description": "selector position",
+                                                                                                                  "mask": 4096,
+                                                                                                             "max_value": 1,
+                                                                                                              "shift_by": 12,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ],
+                                                                 "physical_variant": "toggle_switch"
+                                                          },
+                                          "PLT_WIPER_SW": {
+                                                                         "category": "PLT Cockpit",
+                                                                     "control_type": "selector",
+                                                                      "description": "Pilot Wiper Control Switch, PARK/OFF/LO/HI",
+                                                                       "identifier": "PLT_WIPER_SW",
+                                                                           "inputs": [ {
+                                                                                         "description": "switch to previous or next state",
+                                                                                           "interface": "fixed_step"
+                                                                                     }, {
+                                                                                         "description": "set position",
+                                                                                           "interface": "set_state",
+                                                                                           "max_value": 2
+                                                                                     } ],
+                                                              "momentary_positions": "none",
+                                                                          "outputs": [ {
+                                                                                                               "address": 34568,
+                                                                                         "address_mask_shift_identifier": "AH_64D_PLT_WIPER_SW",
+                                                                                                           "description": "selector position",
+                                                                                                                  "mask": 96,
+                                                                                                             "max_value": 2,
+                                                                                                              "shift_by": 5,
+                                                                                                                "suffix": "",
+                                                                                                                  "type": "integer"
+                                                                                     } ],
+                                                                 "physical_variant": "limited_rotary"
                                                           }
                                  },
           "PLT Emergency Panel": {
@@ -15669,32 +15747,6 @@
                                                                                                                 "type": "integer"
                                                                                    } ],
                                                                "physical_variant": "push_button"
-                                                        },
-                                        "PLT_WIPER_SW": {
-                                                                       "category": "PLT MPD Right",
-                                                                   "control_type": "selector",
-                                                                    "description": "Pilot Wiper Control Switch, PARK/OFF/LO/HI",
-                                                                     "identifier": "PLT_WIPER_SW",
-                                                                         "inputs": [ {
-                                                                                       "description": "switch to previous or next state",
-                                                                                         "interface": "fixed_step"
-                                                                                   }, {
-                                                                                       "description": "set position",
-                                                                                         "interface": "set_state",
-                                                                                         "max_value": 3
-                                                                                   } ],
-                                                            "momentary_positions": "none",
-                                                                        "outputs": [ {
-                                                                                                             "address": 34568,
-                                                                                       "address_mask_shift_identifier": "AH_64D_PLT_WIPER_SW",
-                                                                                                         "description": "selector position",
-                                                                                                                "mask": 96,
-                                                                                                           "max_value": 3,
-                                                                                                            "shift_by": 5,
-                                                                                                              "suffix": "",
-                                                                                                                "type": "integer"
-                                                                                   } ],
-                                                               "physical_variant": "limited_rotary"
                                                         }
                                  },
                 "PLT NVS Panel": {

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
@@ -659,7 +659,7 @@ AH_64D:defineFloat("PLT_CANOPY_POS", 795, { 0, 1 }, "Cockpit Gauges", "Pilot Can
 AH_64D:defineFloat("CPG_CANOPY_POS", 798, { 0, 1 }, "Cockpit Gauges", "Gunner Canopy Position")
 
 --CMWS
-AH_64D:defineSpringloaded_3PosTumb("PLT_CMWS_PW", 80, 3001, 3002, 610, 1, { -1, 0 }, nil, false, "PLT CMWS", "Pilot CMWS PWR Switch, OFF/ON/TEST")
+AH_64D:reserveIntValue(1) -- PLT_CMWS_PW updated from a 2-position to 3-position switch
 AH_64D:definePushButton("PLT_CMWS_PW_TEST", 80, 3002, 610, "PLT CMWS", "Pilot CMWS PWR Switch, TEST")
 AH_64D:definePotentiometer("PLT_CMWS_VOL", 80, 3003, 611, { 0, 1 }, "PLT CMWS", "Pilot CMWS Audio Volume Knob")
 AH_64D:definePotentiometer("PLT_CMWS_LAMP", 80, 3004, 612, { 0, 1 }, "PLT CMWS", "Pilot CMWS Lamp Knob")
@@ -909,5 +909,6 @@ AH_64D:defineReadWriteRadio("FM2_RADIO", 60, 6, 3, 1000, "FM2 Radio")
 AH_64D:defineReadWriteRadio("HF_RADIO", 61, 6, 4, 100, "HF Radio")
 AH_64D:defineToggleSwitch("PLT_WIPER_P_SW", 9, 3023, 357, "PLT Cockpit", "Pilot Wiper Control Switch, PARK")
 AH_64D:defineToggleSwitch("CPG_WIPER_P_SW", 9, 3024, 395, "CPG Cockpit", "Gunner Wiper Control Switch, PARK")
+AH_64D:defineSpringloaded_3PosTumb("PLT_CMWS_PW", 80, 3001, 3002, 610, "PLT CMWS", "Pilot CMWS PWR Switch, OFF/ON/TEST")
 
 return AH_64D

--- a/Scripts/DCS-BIOS/test/AircraftTest.lua
+++ b/Scripts/DCS-BIOS/test/AircraftTest.lua
@@ -1,3 +1,4 @@
+local JSON = require("Scripts.DCS-BIOS.lib.ext.JSON")
 local lu = require("Scripts.DCS-BIOS.test.ext.luaunit")
 
 -- Unit testing starts
@@ -206,6 +207,7 @@ end
 function TestAircraft:validateModule(module, expected_name, expected_address)
 	lu.assertEquals(module.name, expected_name)
 	lu.assertEquals(module.memoryMap.baseAddress, expected_address)
+	JSON:encode(module.documentation) -- verify json generation works
 	self:validateControlNames(module.name, module.documentation)
 end
 


### PR DESCRIPTION
The AH-64D generated JSON files were empty - this is because the modified CMWS line was not valid. I've added JSON serialization to the unit test to catch this sort of thing in the future, and as the CMWS line changed the max value of the control from 1 to 2 I've reserved the old space and moved the control to the end of the file to minimize address changes.