### PR TITLE
Fix A-10C II CMSP switches not working

### DIFF
--- a/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
+++ b/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
@@ -1,5 +1,7 @@
 module("BIOSStateMachine", package.seeall)
 
+local Log = require("Scripts.DCS-BIOS.lib.common.Log")
+
 --- @class BIOSStateMachine
 --- @field private modules_by_name {[string]: Module[]} a map of module names to the modules to send data for
 --- @field private metadata_start MetadataStart the MetadataStart module
@@ -49,7 +51,12 @@ function BIOSStateMachine:processInputLine(line)
 		for _, module in ipairs(self.active_modules) do
 			local processor = module.inputProcessors[cmd]
 			if processor then
-				processor(args)
+				local success, err = pcall(processor, args)
+
+				if not success then
+					Log:log_error(string.format("error processing input for %s", cmd))
+					Log:log_error(err)
+				end
 			end
 		end
 	end

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-10C.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-10C.lua
@@ -46,31 +46,42 @@ function A_10C:defineCMSPSwitch(identifier, device_id, down_command, up_command,
 		elseif toState == "2" then
 			toState = 1
 		else
+			error(string.format("unrecognized toState %d", toState))
+		end
+
+		local fromState = GetDevice(0):get_argument_value(arg_number)
+		local dev = GetDevice(device_id)
+
+		if not dev then
+			error(string.format("unable to get device %d for control %s", device_id, identifier))
 			return
 		end
-		local fromState = string.format("%.1f", GetDevice(0):get_argument_value(arg_number))
-		local fslut = { ["0.0"] = -1, ["0.1"] = 0, ["0.2"] = 1 }
-		local fromStateMapped = fslut[fromState]
-		local dev = GetDevice(device_id)
-		if fromStateMapped == 0 and toState == 1 then
-			dev:performClickableAction(up_command, 0.2)
+
+		if fromState == toState then
+			return -- noop
 		end
-		if fromStateMapped == 1 and toState == 0 then
-			dev:performClickableAction(up_command, 0.1)
-		end
-		if fromStateMapped == 0 and toState == -1 then
-			dev:performClickableAction(down_command, 0.0)
-		end
-		if fromStateMapped == -1 and toState == 0 then
-			dev:performClickableAction(down_command, 0.1)
-		end
-		if fromStateMapped == -1 and toState == 1 then
-			dev:performClickableAction(down_command, 0.1)
-			dev:performClickableAction(up_command, 0.2)
-		end
-		if fromStateMapped == 1 and toState == -1 then
-			dev:performClickableAction(up_command, 0.1)
-			dev:performClickableAction(down_command, 0.0)
+
+		if fromState == -1 then
+			-- for some reason, dev:performClickableAction(down_command, 0) doesn't seem to do anything
+			dev:performClickableAction(down_command, 1)
+			if toState == 1 then
+				-- todo: this doesn't seem to work fully - it will go to 0, but not to 1
+				dev:performClickableAction(up_command, 1)
+			end
+		elseif fromState == 0 then
+			if toState == -1 then
+				dev:performClickableAction(down_command, -1)
+			elseif toState == 1 then
+				dev:performClickableAction(up_command, 1)
+			end
+		elseif fromState == 1 then
+			dev:performClickableAction(up_command, 0)
+
+			if toState == -1 then
+				dev:performClickableAction(down_command, -1)
+			end
+		else
+			error(string.format("unrecognized fromState %d", fromState))
 		end
 	end)
 end

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-10C.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/A-10C.lua
@@ -26,8 +26,8 @@ end
 function A_10C:defineCMSPSwitch(identifier, device_id, down_command, up_command, arg_number, category, description)
 	local alloc = self:allocateInt(2, identifier)
 	self:addExportHook(function(dev0)
-		local lut = { ["0.0"] = 0, ["0.1"] = 1, ["0.2"] = 2 }
-		alloc:setValue(lut[string.format("%.1f", dev0:get_argument_value(arg_number))] or 0)
+		local arg_value = dev0:get_argument_value(arg_number) -- range is -1 to 1
+		alloc:setValue(arg_value + 1)
 	end)
 
 	local control = Control:new(category, ControlType.selector, identifier, description, {


### PR DESCRIPTION
Fixes #495 - mostly. I haven't been able to get -1 to 1 working.

I'm also frankly not sure how this ever worked. Maybe the DCS luas changed recently? But these switches are definitely defined as -1 to 1 in the luas.

I've also added logging to input processing so that if input processing throws, it will be logged. We should be able to utilize this in the future and simply throw when unexpected things happen in input processors, rather than working up some weird logging stuff.