### PR TITLE
Node.js 16 actions are deprecated.

### DIFF
--- a/.github/workflows/release-openbeta.yml
+++ b/.github/workflows/release-openbeta.yml
@@ -16,7 +16,7 @@ jobs:
     name: Run unit tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up lua
         uses: leafo/gh-actions-lua@v10
@@ -41,7 +41,7 @@ jobs:
     name: Release zip file
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -12,10 +12,10 @@ jobs:
     name: Validate style
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Stylua check
-        uses: JohnnyMorganz/stylua-action@v3
+        uses: JohnnyMorganz/stylua-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           version: 0.17.0 # pin to a specific version in case of formatting changes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     name: Run unit tests
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up lua
         uses: leafo/gh-actions-lua@v10


### PR DESCRIPTION
Update some of GH actions used in project.

Note: `leafo/gh-actions-lua` lag behind, but there is open issue for:  
leafo/gh-actions-lua#42

For more information see:  
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/