### PR TITLE
AH-64D::PLT_SAI_PITCH_TRIM change command

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
@@ -185,6 +185,8 @@ AH_64D:definePotentiometer("CPG_INTL_FLOOD_L_KNB", 11, 3014, 366, { 0, 1 }, "CPG
 
 -- Standby Attitude Indicator
 AH_64D:definePushButton("PLT_SAI_CAGE", 13, 3001, 620, "PLT SAI", "Pilot SAI Cage Knob, (LMB) Pull to cage")
+-- See https://github.com/DCS-Skunkworks/dcs-bios/pull/550
+-- Command 3002 stopped working, testing showed 3004 works. ???  05 March 2024
 AH_64D:defineRotary("PLT_SAI_PITCH_TRIM", 13, 3004, 619, "PLT SAI", "Pilot SAI Cage Knob, (MW) Adjust aircraft reference symbol")
 
 AH_64D:defineFloat("PLT_SAI_PITCH", 622, { -0.95, 0.95 }, "PLT SAI Gauges", "Pilot SAI Pitch")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/AH-64D.lua
@@ -185,7 +185,7 @@ AH_64D:definePotentiometer("CPG_INTL_FLOOD_L_KNB", 11, 3014, 366, { 0, 1 }, "CPG
 
 -- Standby Attitude Indicator
 AH_64D:definePushButton("PLT_SAI_CAGE", 13, 3001, 620, "PLT SAI", "Pilot SAI Cage Knob, (LMB) Pull to cage")
-AH_64D:defineRotary("PLT_SAI_PITCH_TRIM", 13, 3002, 619, "PLT SAI", "Pilot SAI Cage Knob, (MW) Adjust aircraft reference symbol")
+AH_64D:defineRotary("PLT_SAI_PITCH_TRIM", 13, 3004, 619, "PLT SAI", "Pilot SAI Cage Knob, (MW) Adjust aircraft reference symbol")
 
 AH_64D:defineFloat("PLT_SAI_PITCH", 622, { -0.95, 0.95 }, "PLT SAI Gauges", "Pilot SAI Pitch")
 AH_64D:defineFloat("PLT_SAI_BANK", 623, { 1, -1 }, "PLT SAI Gauges", "Pilot SAI Bank")


### PR DESCRIPTION
The command was 3002 which is what it looks like it should be based on ```command_defs.lua``` but testing with insight command 3004 works.
edit:
3002 did not work with BIOSBuddy / dcs-insight.

```elements["pnt_619"]		= default_button_axis(CREW.PLT, _("SAI Cage Knob, (LMB) Pull to cage /(MW) Adjust aircraft reference symbol"),	devices.SAI, sai_commands.CageKnobPull, sai_commands.CageKnobRotate, 620, 619)```

![4](https://github.com/DCS-Skunkworks/dcs-bios/assets/10453261/2ea3fd78-ee2f-4a2b-ac9c-166ef1114884)

![1](https://github.com/DCS-Skunkworks/dcs-bios/assets/10453261/b5d76468-710c-4f4c-afbf-1bf22a187bb0)

![2](https://github.com/DCS-Skunkworks/dcs-bios/assets/10453261/7e92b605-9c6f-4716-a9c7-365624a93d21)

![3](https://github.com/DCS-Skunkworks/dcs-bios/assets/10453261/40af44bb-9ef5-4f1a-ba49-7af4dd220871)

