### PR TITLE
Set RTS option and explain its effect

### DIFF
--- a/Programs/connect-serial-port.cmd
+++ b/Programs/connect-serial-port.cmd
@@ -26,8 +26,9 @@ if "%COMPORT%" == "ASK" set /p COMPORT=Enter a COM Port Number:
 
 set /A TTYNUM=%COMPORT%-1
 if "%MODE_OUTPUT_REDIR%" == "NUL" echo Connecting to COM port %COMPORT%
-REM The DTR and RTS settings in the next line effect whether the microcontroller restarts when the port opens. Change them if needed!
-mode COM%COMPORT% BAUD=250000 PARITY=N DATA=8 STOP=1 TO=off DTR=off RTS=on %MODE_OUTPUT_REDIR%
+REM The DTR and RTS settings to the mode command effect whether the microcontroller restarts when the port opens.
+REM Different combinations of DTR/RTS={on|off} might be needed depending on the type of board, and whether you want it to restart.
+mode COM%COMPORT% BAUD=250000 PARITY=N DATA=8 STOP=1 TO=off DTR=off %MODE_OUTPUT_REDIR%
 timeout 5
 if "%PROTOCOL%" == "UDP" socat\socat %VERBOSE% UDP4-RECV:5010,ip-add-membership=239.255.50.10:0.0.0.0,reuseaddr!!udp-sendto:localhost:7778 /dev/ttyS%TTYNUM%
 if "%PROTOCOL%" == "TCP" socat\socat %VERBOSE% TCP4-CONNECT:127.0.0.1:7778 /dev/ttyS%TTYNUM%

--- a/Programs/connect-serial-port.cmd
+++ b/Programs/connect-serial-port.cmd
@@ -26,7 +26,8 @@ if "%COMPORT%" == "ASK" set /p COMPORT=Enter a COM Port Number:
 
 set /A TTYNUM=%COMPORT%-1
 if "%MODE_OUTPUT_REDIR%" == "NUL" echo Connecting to COM port %COMPORT%
-mode COM%COMPORT% BAUD=250000 PARITY=N DATA=8 STOP=1 TO=off DTR=off %MODE_OUTPUT_REDIR%
+REM The DTR and RTS settings in the next line effect whether the microcontroller restarts when the port opens. Change them if needed!
+mode COM%COMPORT% BAUD=250000 PARITY=N DATA=8 STOP=1 TO=off DTR=off RTS=on %MODE_OUTPUT_REDIR%
 timeout 5
 if "%PROTOCOL%" == "UDP" socat\socat %VERBOSE% UDP4-RECV:5010,ip-add-membership=239.255.50.10:0.0.0.0,reuseaddr!!udp-sendto:localhost:7778 /dev/ttyS%TTYNUM%
 if "%PROTOCOL%" == "TCP" socat\socat %VERBOSE% TCP4-CONNECT:127.0.0.1:7778 /dev/ttyS%TTYNUM%


### PR DESCRIPTION
I struggled with unreliable connection initialization with my ESP32-based panel.
The command line was sometimes all garbled up and sometimes not.

My ESP32 was restarting every time the COM port was opened/closed, and since it takes ~10 seconds to initialize, it wouldn't reliably establish the connection.

I found that `DTS` and `RTS` are both misused as a reset signal, and after setting `RTS=off` the restarts disappeared and the connection not initializes reliably.

To help other people I would propose to set the `RTS` option explicitly.