### PR TITLE
Mi-24P: Fix ALT_SHUTTER controls out of range

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/Module.lua
+++ b/Scripts/DCS-BIOS/lib/modules/Module.lua
@@ -1292,8 +1292,25 @@ end
 function Module.valueConvert(argument_value, input_range, output_range)
 	assert_min_max(input_range, "input_range")
 	assert_min_max(output_range, "output_range")
-	local slope = 1.0 * (output_range[2] - output_range[1]) / (input_range[2] - input_range[1])
-	return output_range[1] + slope * (argument_value - input_range[1])
+
+	-- if we're close enough to our input range, snap to that value
+	-- this helps avoid out of range issues mapping from small input ranges to large output ranges
+	local epsilon = 0.000072 -- for the smallest known range in dcs {0.822, 0.75} -> 0.072, this is about 0.1%
+
+	local input_min = input_range[1]
+	local input_max = input_range[2]
+	local output_min = output_range[1]
+	local output_max = output_range[2]
+
+	if math.abs(argument_value - input_min) < epsilon then
+		return output_min
+	end
+	if math.abs(argument_value - input_max) < epsilon then
+		return output_max
+	end
+
+	local slope = 1.0 * (output_max - output_min) / (input_max - input_min)
+	return output_min + slope * (argument_value - input_min)
 end
 
 --- Returns an integer from individual arguments ordered from least to most significant digit

--- a/Scripts/DCS-BIOS/test/controls/FloatTest.lua
+++ b/Scripts/DCS-BIOS/test/controls/FloatTest.lua
@@ -118,3 +118,25 @@ function TestFloat:testFloatDecimalValue()
 	export_hook(MockDevice:new(0.5))
 	lu.assertEquals(alloc.value, 65535)
 end
+
+function TestFloat:testFloatSmallRangeValue()
+	local limits = { 0.822, 0.75 }
+
+	self.module:defineFloat(id, arg_number, limits, category, description)
+
+	local export_hook = self.module.exportHooks[1]
+
+	local alloc = self.module.memoryMap.entries[moduleAddress].allocations[1]
+
+	export_hook(MockDevice:new(0.82205))
+	lu.assertEquals(alloc.value, 0)
+
+	export_hook(MockDevice:new(0.74995))
+	lu.assertEquals(alloc.value, 65535)
+
+	export_hook(MockDevice:new(0.822))
+	lu.assertEquals(alloc.value, 0)
+
+	export_hook(MockDevice:new(0.75))
+	lu.assertEquals(alloc.value, 65535)
+end


### PR DESCRIPTION
Fixes #791

This control maps a range from dcs of `{ 0.822, 0.75 }` to our `{0, 65535}`. This means we're mapping floats within a span of `0.072` to a span of `65535` - meaning every increment of one on our end equates to an increment of 0.0000011 within the simulation. This is pushing the limits of floating point precision.

Instead, we can catch this at the outset with a reasonable epsilon. An epsilon of `0.000072` means we'll "stick" to the ends within the first 0.1% (65 / 65535), which shouldn't be noticeable for any consumer.