### PR TITLE
F/A-18C: Add exports for laser status on HUD/DDI

### DIFF
--- a/Scripts/DCS-BIOS/doc/Addresses.h
+++ b/Scripts/DCS-BIOS/doc/Addresses.h
@@ -7308,6 +7308,7 @@
 #define FA_18C_hornet_HUD_BALANCE_A 0x745C
 #define FA_18C_hornet_HUD_BLACK_LVL 0x745A, 0xFFFF, 0
 #define FA_18C_hornet_HUD_BLACK_LVL_A 0x745A
+#define FA_18C_hornet_HUD_LTDR_A 0x75A2
 #define FA_18C_hornet_HUD_SYM_BRT 0x7458, 0xFFFF, 0
 #define FA_18C_hornet_HUD_SYM_BRT_A 0x7458
 #define FA_18C_hornet_HUD_SYM_BRT_SELECT 0x742C, 0x0800, 11
@@ -7419,6 +7420,7 @@
 #define FA_18C_hornet_LEFT_DDI_CONT_CTL_A 0x7412
 #define FA_18C_hornet_LEFT_DDI_CRS_SW 0x74A8, 0x6000, 13
 #define FA_18C_hornet_LEFT_DDI_HDG_SW 0x74A8, 0x1800, 11
+#define FA_18C_hornet_LEFT_DDI_LTDR_A 0x75A8
 #define FA_18C_hornet_LEFT_DDI_PB_01 0x740E, 0x0008, 3
 #define FA_18C_hornet_LEFT_DDI_PB_01_AM 0x740E, 0x0008
 #define FA_18C_hornet_LEFT_DDI_PB_02 0x740E, 0x0010, 4
@@ -7582,6 +7584,7 @@
 #define FA_18C_hornet_RIGHT_DDI_BRT_SELECT 0x7418, 0x0060, 5
 #define FA_18C_hornet_RIGHT_DDI_CONT_CTL 0x7454, 0xFFFF, 0
 #define FA_18C_hornet_RIGHT_DDI_CONT_CTL_A 0x7454
+#define FA_18C_hornet_RIGHT_DDI_LTDR_A 0x75AE
 #define FA_18C_hornet_RIGHT_DDI_PB_01 0x7418, 0x0080, 7
 #define FA_18C_hornet_RIGHT_DDI_PB_01_AM 0x7418, 0x0080
 #define FA_18C_hornet_RIGHT_DDI_PB_02 0x7418, 0x0100, 8

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -973,4 +973,8 @@ FA_18C_hornet:defineToggleSwitch("KY58_FILL_SEL_PULL", 41, 3003, 0, "KY-58 Contr
 FA_18C_hornet:defineReadWriteRadio("COMM1", 38, 7, 3, 1000, "COMM1 Radio")
 FA_18C_hornet:defineReadWriteRadio("COMM2", 39, 7, 3, 1000, "COMM2 Radio")
 
+FA_18C_hornet:defineString("HUD_LTDR", function()
+	return Functions.coerce_nil_to_string(Module.parse_indication(1)["MPD_FLIR_LaserStatus_label"])
+end, 5, "HUD", "Laser Status")
+
 return FA_18C_hornet


### PR DESCRIPTION
Fixes #855

Opted to just implement the HUD line as the DDI lines would only show when on the FLIR page, whereas the HUD line should always show (provided the HUD is on).