### PR TITLE
F-15E MFD text export

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
@@ -1178,11 +1178,11 @@ local F_MPCD_BUTTONS = {}
 local F_MPDR_BUTTONS = {}
 
 local function split(stringvalue, delimiter)
-    local result = {};
-    for match in (stringvalue .. delimiter):gmatch("(.-)" .. delimiter) do
-        table.insert(result, match);
-    end
-    return result;
+	local result = {}
+	for match in (stringvalue .. delimiter):gmatch("(.-)" .. delimiter) do
+		table.insert(result, match)
+	end
+	return result
 end
 
 --[[ types PB entries may be missing ; write entries only if they're nil,  "`" or "^" ; add child values with $ for splitting ; only acceptable suffix is _LABEL ;
@@ -1196,62 +1196,74 @@ PB%d%d_PB%d%d					PB12_PB13 for split on PB12 and PB13
 PB%d%d_Value					is data begins 3 lines after "children are {" line
 PB%d%d%d%d						PB0405 for split between 04 and 05
 PB%d%d_%d%d						PB13_14 for split between 13 and 14
-]]--
+]]
+--
 
-local function parseMFDButtons(stringindication)
-	local input = split(stringindication, "%c")
-	local values = {};
+-- matches for various pushbutton label names
+local matchers = {
+	{ "^PB(%d[%d]?)$", false },
+	{ "^[%a+_]+PB(%d+)[_LABEL]-$", false },
+	{ "^PB(%d+)%-%d+$", true },
+	{ "^PB(%d%d)[%d%d|_PB%d%d|_%d%d]+$", true },
+}
+
+-- function for matching the "PB____" button descriptors
+local function match_button_descriptors(val)
+	for _, pair in ipairs(matchers) do
+		local pos = string.match(val, pair[1])
+		if pos then
+			return tonumber(pos), pair[2]
+		end
+	end
+	return nil, nil
+end
+
+-- function for parsing the button labels
+local function parseMFDButtons(indicationID)
+	local input = split(list_indication(indicationID), "%c")
+	if not input then
+		return nil
+	end
+	local values = {}
 	for numline, checkline in pairs(input) do
-		if checkline  and string.sub(checkline, 1, 1) == "-" then
-			local start = numline+1
+		if checkline and string.sub(checkline, 1, 1) == "-" then -- a line of dashes denotes the start/end of a value grouping
+			local start = numline + 1
 			local val = input[start]
-			local double = false
 			if val then
-				local pos = string.match(val, "^PB(%d[%d]?)$")
-				if not pos then
-					pos = string.match(val, "^[%a+_]+PB(%d+)[_LABEL]-$")
-					if not pos then
-						pos = string.match(val, "^PB(%d+)%-%d+$")
-						if not pos then
-							pos = string.match(val, "^PB(%d%d)[%d%d|_PB%d%d|_%d%d]+$")
-							double = true
-						else
-							double = true
-						end
-					end
-				end
-				if pos then
-					local num = tonumber(pos)
+				local num, double = match_button_descriptors(val) -- check if its one of the PB lines
+				if num then
 					local combine = ""
-					for i = start+1, #input do
+					for i = start + 1, #input do -- real values start 1 line after the PB___ stuff
 						local line = input[i]
 						if line then
-							if string.sub(line, 1,1) ~="-" and line ~= "children are {" then
-								combine = combine .. line
-							elseif line == "children are {" then
+							if line == "children are {" then -- check for sub-value (child)
 								combine = combine .. "$"
-								for j = i+3, #input do
+								for j = i + 3, #input do -- sub-values start 3 lines after the beginning "children are" line
 									local childline = input[j]
-									if line and string.sub(childline, 1, 1) ~= "}" then
+									if line and string.sub(childline, 1, 1) ~= "}" then -- sub-values end with }
 										combine = combine .. childline
 									else
 										break
 									end
 								end
+							elseif string.sub(line, 1, 1) ~= "-" then -- check if value group ended with dashes
+								combine = combine .. line
 							else
 								break
 							end
 						end
 					end
-					if not double then
-						if (not values[num] or string.match(values[num], "^[`%^]$")) and combine ~= "" then
-							values[num] = combine
+					if double then
+						if (not values[num] and not values[num + 1]) or (string.match(values[num], "^[`%^]$") and string.match(values[num + 1], "^[`%^]$")) then
+							local startnum = string.find(combine, "%d")
+							if startnum then
+								values[num + (num > 10 and 1 or 0)] = string.sub(combine, 1, startnum - 1) -- if the buttons is on the right or top, reverse the order so the top has text
+								values[num + (num > 10 and 0 or 1)] = string.sub(combine, startnum, #combine) -- and the bottom has the number (like how its displayed)
+							end
 						end
 					else
-						if (not values[num] and not values[num+1]) or (string.match(values[num], "^[`%^]$") and string.match(values[num+1], "^[`%^]$")) then
-							local startnum = string.find(combine, "%d")
-							values[num + (num>10 and 1 or 0)] = string.sub(combine, 1, startnum-1)
-							values[num + (num>10 and 0 or 1)] = string.sub(combine, startnum, #combine)
+						if (not values[num] or string.match(values[num], "^[`%^]$")) and combine ~= "" then -- up/down arrows are ´/^ so they should be overwritten
+							values[num] = combine
 						end
 					end
 				end
@@ -1259,222 +1271,219 @@ local function parseMFDButtons(stringindication)
 		end
 	end
 
-	for i = 1, 20 do
+	for i = 1, 20 do -- fill the rest with spaces
 		if not values[i] then
-			values[i] = "          "
+			values[i] = " "
 		end
 	end
 	return values
-
 end
 
 F_15E:addExportHook(function()
-	local input = list_indication(3)
-	if not input then
+	local output = parseMFDButtons(3)
+	if not output then
 		return
 	end
-	F_MPDL_BUTTONS = parseMFDButtons(input)
+	F_MPDL_BUTTONS = output
 end)
 
 F_15E:addExportHook(function()
-	local input = list_indication(5)
-	if not input then
+	local output = parseMFDButtons(5)
+	if not output then
 		return
 	end
-	
-	F_MPCD_BUTTONS = parseMFDButtons(input)
+	F_MPCD_BUTTONS = output
 end)
 
 F_15E:addExportHook(function()
-	local input = list_indication(7)
-	if not input then
+	local output = parseMFDButtons(7)
+	if not output then
 		return
 	end
-	
-	F_MPDR_BUTTONS = parseMFDButtons(input)
+	F_MPDR_BUTTONS = output
 end)
 
 F_15E:defineString("F_MPDL_PBLABEL_01", function()
-    return F_MPDL_BUTTONS[1]
+	return F_MPDL_BUTTONS[1]
 end, 10, "Front Left MPD Labels", "PB 01")
 F_15E:defineString("F_MPDL_PBLABEL_02", function()
-    return F_MPDL_BUTTONS[2]
+	return F_MPDL_BUTTONS[2]
 end, 10, "Front Left MPD Labels", "PB 02")
 F_15E:defineString("F_MPDL_PBLABEL_03", function()
-    return F_MPDL_BUTTONS[3]
+	return F_MPDL_BUTTONS[3]
 end, 10, "Front Left MPD Labels", "PB 03")
 F_15E:defineString("F_MPDL_PBLABEL_04", function()
-    return F_MPDL_BUTTONS[4]
+	return F_MPDL_BUTTONS[4]
 end, 10, "Front Left MPD Labels", "PB 04")
 F_15E:defineString("F_MPDL_PBLABEL_05", function()
-    return F_MPDL_BUTTONS[5]
+	return F_MPDL_BUTTONS[5]
 end, 10, "Front Left MPD Labels", "PB 05")
 F_15E:defineString("F_MPDL_PBLABEL_06", function()
-    return F_MPDL_BUTTONS[6]
+	return F_MPDL_BUTTONS[6]
 end, 10, "Front Left MPD Labels", "PB 06")
 F_15E:defineString("F_MPDL_PBLABEL_07", function()
-    return F_MPDL_BUTTONS[7]
+	return F_MPDL_BUTTONS[7]
 end, 10, "Front Left MPD Labels", "PB 07")
 F_15E:defineString("F_MPDL_PBLABEL_08", function()
-    return F_MPDL_BUTTONS[8]
+	return F_MPDL_BUTTONS[8]
 end, 10, "Front Left MPD Labels", "PB 08")
 F_15E:defineString("F_MPDL_PBLABEL_09", function()
-    return F_MPDL_BUTTONS[9]
+	return F_MPDL_BUTTONS[9]
 end, 10, "Front Left MPD Labels", "PB 09")
 F_15E:defineString("F_MPDL_PBLABEL_10", function()
-    return F_MPDL_BUTTONS[10]
+	return F_MPDL_BUTTONS[10]
 end, 10, "Front Left MPD Labels", "PB 10")
 F_15E:defineString("F_MPDL_PBLABEL_11", function()
-    return F_MPDL_BUTTONS[11]
+	return F_MPDL_BUTTONS[11]
 end, 10, "Front Left MPD Labels", "PB 11")
 F_15E:defineString("F_MPDL_PBLABEL_12", function()
-    return F_MPDL_BUTTONS[12]
+	return F_MPDL_BUTTONS[12]
 end, 10, "Front Left MPD Labels", "PB 12")
 F_15E:defineString("F_MPDL_PBLABEL_13", function()
-    return F_MPDL_BUTTONS[13]
+	return F_MPDL_BUTTONS[13]
 end, 10, "Front Left MPD Labels", "PB 13")
 F_15E:defineString("F_MPDL_PBLABEL_14", function()
-    return F_MPDL_BUTTONS[14]
+	return F_MPDL_BUTTONS[14]
 end, 10, "Front Left MPD Labels", "PB 14")
 F_15E:defineString("F_MPDL_PBLABEL_15", function()
-    return F_MPDL_BUTTONS[15]
+	return F_MPDL_BUTTONS[15]
 end, 10, "Front Left MPD Labels", "PB 15")
 F_15E:defineString("F_MPDL_PBLABEL_16", function()
-    return F_MPDL_BUTTONS[16]
+	return F_MPDL_BUTTONS[16]
 end, 10, "Front Left MPD Labels", "PB 16")
 F_15E:defineString("F_MPDL_PBLABEL_17", function()
-    return F_MPDL_BUTTONS[17]
+	return F_MPDL_BUTTONS[17]
 end, 10, "Front Left MPD Labels", "PB 17")
 F_15E:defineString("F_MPDL_PBLABEL_18", function()
-    return F_MPDL_BUTTONS[18]
+	return F_MPDL_BUTTONS[18]
 end, 10, "Front Left MPD Labels", "PB 18")
 F_15E:defineString("F_MPDL_PBLABEL_19", function()
-    return F_MPDL_BUTTONS[19]
+	return F_MPDL_BUTTONS[19]
 end, 10, "Front Left MPD Labels", "PB 19")
 F_15E:defineString("F_MPDL_PBLABEL_20", function()
-    return F_MPDL_BUTTONS[20]
+	return F_MPDL_BUTTONS[20]
 end, 10, "Front Left MPD Labels", "PB 20")
 
 F_15E:defineString("F_MPCD_PBLABEL_01", function()
-    return F_MPCD_BUTTONS[1]
+	return F_MPCD_BUTTONS[1]
 end, 10, "Front Center MPCD Labels", "PB 01")
 F_15E:defineString("F_MPCD_PBLABEL_02", function()
-    return F_MPCD_BUTTONS[2]
+	return F_MPCD_BUTTONS[2]
 end, 10, "Front Center MPCD Labels", "PB 02")
 F_15E:defineString("F_MPCD_PBLABEL_03", function()
-    return F_MPCD_BUTTONS[3]
+	return F_MPCD_BUTTONS[3]
 end, 10, "Front Center MPCD Labels", "PB 03")
 F_15E:defineString("F_MPCD_PBLABEL_04", function()
-    return F_MPCD_BUTTONS[4]
+	return F_MPCD_BUTTONS[4]
 end, 10, "Front Center MPCD Labels", "PB 04")
 F_15E:defineString("F_MPCD_PBLABEL_05", function()
-    return F_MPCD_BUTTONS[5]
+	return F_MPCD_BUTTONS[5]
 end, 10, "Front Center MPCD Labels", "PB 05")
 F_15E:defineString("F_MPCD_PBLABEL_06", function()
-    return F_MPCD_BUTTONS[6]
+	return F_MPCD_BUTTONS[6]
 end, 10, "Front Center MPCD Labels", "PB 06")
 F_15E:defineString("F_MPCD_PBLABEL_07", function()
-    return F_MPCD_BUTTONS[7]
+	return F_MPCD_BUTTONS[7]
 end, 10, "Front Center MPCD Labels", "PB 07")
 F_15E:defineString("F_MPCD_PBLABEL_08", function()
-    return F_MPCD_BUTTONS[8]
+	return F_MPCD_BUTTONS[8]
 end, 10, "Front Center MPCD Labels", "PB 08")
 F_15E:defineString("F_MPCD_PBLABEL_09", function()
-    return F_MPCD_BUTTONS[9]
+	return F_MPCD_BUTTONS[9]
 end, 10, "Front Center MPCD Labels", "PB 09")
 F_15E:defineString("F_MPCD_PBLABEL_10", function()
-    return F_MPCD_BUTTONS[10]
+	return F_MPCD_BUTTONS[10]
 end, 10, "Front Center MPCD Labels", "PB 10")
 F_15E:defineString("F_MPCD_PBLABEL_11", function()
-    return F_MPCD_BUTTONS[11]
+	return F_MPCD_BUTTONS[11]
 end, 10, "Front Center MPCD Labels", "PB 11")
 F_15E:defineString("F_MPCD_PBLABEL_12", function()
-    return F_MPCD_BUTTONS[12]
+	return F_MPCD_BUTTONS[12]
 end, 10, "Front Center MPCD Labels", "PB 12")
 F_15E:defineString("F_MPCD_PBLABEL_13", function()
-    return F_MPCD_BUTTONS[13]
+	return F_MPCD_BUTTONS[13]
 end, 10, "Front Center MPCD Labels", "PB 13")
 F_15E:defineString("F_MPCD_PBLABEL_14", function()
-    return F_MPCD_BUTTONS[14]
+	return F_MPCD_BUTTONS[14]
 end, 10, "Front Center MPCD Labels", "PB 14")
 F_15E:defineString("F_MPCD_PBLABEL_15", function()
-    return F_MPCD_BUTTONS[15]
+	return F_MPCD_BUTTONS[15]
 end, 10, "Front Center MPCD Labels", "PB 15")
 F_15E:defineString("F_MPCD_PBLABEL_16", function()
-    return F_MPCD_BUTTONS[16]
+	return F_MPCD_BUTTONS[16]
 end, 10, "Front Center MPCD Labels", "PB 16")
 F_15E:defineString("F_MPCD_PBLABEL_17", function()
-    return F_MPCD_BUTTONS[17]
+	return F_MPCD_BUTTONS[17]
 end, 10, "Front Center MPCD Labels", "PB 17")
 F_15E:defineString("F_MPCD_PBLABEL_18", function()
-    return F_MPCD_BUTTONS[18]
+	return F_MPCD_BUTTONS[18]
 end, 10, "Front Center MPCD Labels", "PB 18")
 F_15E:defineString("F_MPCD_PBLABEL_19", function()
-    return F_MPCD_BUTTONS[19]
+	return F_MPCD_BUTTONS[19]
 end, 10, "Front Center MPCD Labels", "PB 19")
 F_15E:defineString("F_MPCD_PBLABEL_20", function()
-    return F_MPCD_BUTTONS[20]
+	return F_MPCD_BUTTONS[20]
 end, 10, "Front Center MPCD Labels", "PB 20")
 
 F_15E:defineString("F_MPDR_PBLABEL_01", function()
-    return F_MPDR_BUTTONS[1]
+	return F_MPDR_BUTTONS[1]
 end, 10, "Front Right MPD Labels", "PB 01")
 F_15E:defineString("F_MPDR_PBLABEL_02", function()
-    return F_MPDR_BUTTONS[2]
+	return F_MPDR_BUTTONS[2]
 end, 10, "Front Right MPD Labels", "PB 02")
 F_15E:defineString("F_MPDR_PBLABEL_03", function()
-    return F_MPDR_BUTTONS[3]
+	return F_MPDR_BUTTONS[3]
 end, 10, "Front Right MPD Labels", "PB 03")
 F_15E:defineString("F_MPDR_PBLABEL_04", function()
-    return F_MPDR_BUTTONS[4]
+	return F_MPDR_BUTTONS[4]
 end, 10, "Front Right MPD Labels", "PB 04")
 F_15E:defineString("F_MPDR_PBLABEL_05", function()
-    return F_MPDR_BUTTONS[5]
+	return F_MPDR_BUTTONS[5]
 end, 10, "Front Right MPD Labels", "PB 05")
 F_15E:defineString("F_MPDR_PBLABEL_06", function()
-    return F_MPDR_BUTTONS[6]
+	return F_MPDR_BUTTONS[6]
 end, 10, "Front Right MPD Labels", "PB 06")
 F_15E:defineString("F_MPDR_PBLABEL_07", function()
-    return F_MPDR_BUTTONS[7]
+	return F_MPDR_BUTTONS[7]
 end, 10, "Front Right MPD Labels", "PB 07")
 F_15E:defineString("F_MPDR_PBLABEL_08", function()
-    return F_MPDR_BUTTONS[8]
+	return F_MPDR_BUTTONS[8]
 end, 10, "Front Right MPD Labels", "PB 08")
 F_15E:defineString("F_MPDR_PBLABEL_09", function()
-    return F_MPDR_BUTTONS[9]
+	return F_MPDR_BUTTONS[9]
 end, 10, "Front Right MPD Labels", "PB 09")
 F_15E:defineString("F_MPDR_PBLABEL_10", function()
-    return F_MPDR_BUTTONS[10]
+	return F_MPDR_BUTTONS[10]
 end, 10, "Front Right MPD Labels", "PB 10")
 F_15E:defineString("F_MPDR_PBLABEL_11", function()
-    return F_MPDR_BUTTONS[11]
+	return F_MPDR_BUTTONS[11]
 end, 10, "Front Right MPD Labels", "PB 11")
 F_15E:defineString("F_MPDR_PBLABEL_12", function()
-    return F_MPDR_BUTTONS[12]
+	return F_MPDR_BUTTONS[12]
 end, 10, "Front Right MPD Labels", "PB 12")
 F_15E:defineString("F_MPDR_PBLABEL_13", function()
-    return F_MPDR_BUTTONS[13]
+	return F_MPDR_BUTTONS[13]
 end, 10, "Front Right MPD Labels", "PB 13")
 F_15E:defineString("F_MPDR_PBLABEL_14", function()
-    return F_MPDR_BUTTONS[14]
+	return F_MPDR_BUTTONS[14]
 end, 10, "Front Right MPD Labels", "PB 14")
 F_15E:defineString("F_MPDR_PBLABEL_15", function()
-    return F_MPDR_BUTTONS[15]
+	return F_MPDR_BUTTONS[15]
 end, 10, "Front Right MPD Labels", "PB 15")
 F_15E:defineString("F_MPDR_PBLABEL_16", function()
-    return F_MPDR_BUTTONS[16]
+	return F_MPDR_BUTTONS[16]
 end, 10, "Front Right MPD Labels", "PB 16")
 F_15E:defineString("F_MPDR_PBLABEL_17", function()
-    return F_MPDR_BUTTONS[17]
+	return F_MPDR_BUTTONS[17]
 end, 10, "Front Right MPD Labels", "PB 17")
 F_15E:defineString("F_MPDR_PBLABEL_18", function()
-    return F_MPDR_BUTTONS[18]
+	return F_MPDR_BUTTONS[18]
 end, 10, "Front Right MPD Labels", "PB 18")
 F_15E:defineString("F_MPDR_PBLABEL_19", function()
-    return F_MPDR_BUTTONS[19]
+	return F_MPDR_BUTTONS[19]
 end, 10, "Front Right MPD Labels", "PB 19")
 F_15E:defineString("F_MPDR_PBLABEL_20", function()
-    return F_MPDR_BUTTONS[20]
+	return F_MPDR_BUTTONS[20]
 end, 10, "Front Right MPD Labels", "PB 20")
 
 local R_MPCDL_BUTTONS = {}
@@ -1486,282 +1495,282 @@ local R_MPDR_BUTTONS = {}
 local R_MPCDR_BUTTONS = {}
 
 F_15E:addExportHook(function()
-	local input = list_indication(10)
-	if not input then
+	local output = parseMFDButtons(10)
+	if not output then
 		return
 	end
-	R_MPCDL_BUTTONS = parseMFDButtons(input)
+	R_MPCDL_BUTTONS = output
 end)
 
 F_15E:addExportHook(function()
-	local input = list_indication(12)
-	if not input then
+	local output = parseMFDButtons(12)
+	if not output then
 		return
 	end
-	
-	R_MPDL_BUTTONS = parseMFDButtons(input)
+
+	R_MPDL_BUTTONS = output
 end)
 
 F_15E:addExportHook(function()
-	local input = list_indication(14)
-	if not input then
+	local output = parseMFDButtons(14)
+	if not output then
 		return
 	end
-	
-	R_MPDR_BUTTONS = parseMFDButtons(input)
+
+	R_MPDR_BUTTONS = output
 end)
 
 F_15E:addExportHook(function()
-	local input = list_indication(16)
-	if not input then
+	local output = parseMFDButtons(16)
+	if not output then
 		return
 	end
-	
-	R_MPCDR_BUTTONS = parseMFDButtons(input)
+
+	R_MPCDR_BUTTONS = output
 end)
 
-F_15E:defineString("R_MPCDL_PBLABEL_01", function() 
-    return R_MPCDL_BUTTONS[1]
+F_15E:defineString("R_MPCDL_PBLABEL_01", function()
+	return R_MPCDL_BUTTONS[1]
 end, 10, "Rear Left MPCD Labels", "PB 01")
-F_15E:defineString("R_MPCDL_PBLABEL_02", function() 
-    return R_MPCDL_BUTTONS[2]
+F_15E:defineString("R_MPCDL_PBLABEL_02", function()
+	return R_MPCDL_BUTTONS[2]
 end, 10, "Rear Left MPCD Labels", "PB 02")
 F_15E:defineString("R_MPCDL_PBLABEL_03", function()
-    return R_MPCDL_BUTTONS[3]
+	return R_MPCDL_BUTTONS[3]
 end, 10, "Rear Left MPCD Labels", "PB 03")
-F_15E:defineString("R_MPCDL_PBLABEL_04", function() 
-    return R_MPCDL_BUTTONS[4]
+F_15E:defineString("R_MPCDL_PBLABEL_04", function()
+	return R_MPCDL_BUTTONS[4]
 end, 10, "Rear Left MPCD Labels", "PB 04")
-F_15E:defineString("R_MPCDL_PBLABEL_05", function() 
-    return R_MPCDL_BUTTONS[5]
+F_15E:defineString("R_MPCDL_PBLABEL_05", function()
+	return R_MPCDL_BUTTONS[5]
 end, 10, "Rear Left MPCD Labels", "PB 05")
-F_15E:defineString("R_MPCDL_PBLABEL_06", function() 
-    return R_MPCDL_BUTTONS[6]
+F_15E:defineString("R_MPCDL_PBLABEL_06", function()
+	return R_MPCDL_BUTTONS[6]
 end, 10, "Rear Left MPCD Labels", "PB 06")
-F_15E:defineString("R_MPCDL_PBLABEL_07", function() 
-    return R_MPCDL_BUTTONS[7]
+F_15E:defineString("R_MPCDL_PBLABEL_07", function()
+	return R_MPCDL_BUTTONS[7]
 end, 10, "Rear Left MPCD Labels", "PB 07")
-F_15E:defineString("R_MPCDL_PBLABEL_08", function() 
-    return R_MPCDL_BUTTONS[8]
+F_15E:defineString("R_MPCDL_PBLABEL_08", function()
+	return R_MPCDL_BUTTONS[8]
 end, 10, "Rear Left MPCD Labels", "PB 08")
-F_15E:defineString("R_MPCDL_PBLABEL_09", function() 
-    return R_MPCDL_BUTTONS[9]
+F_15E:defineString("R_MPCDL_PBLABEL_09", function()
+	return R_MPCDL_BUTTONS[9]
 end, 10, "Rear Left MPCD Labels", "PB 9")
-F_15E:defineString("R_MPCDL_PBLABEL_10", function() 
-    return R_MPCDL_BUTTONS[10]
+F_15E:defineString("R_MPCDL_PBLABEL_10", function()
+	return R_MPCDL_BUTTONS[10]
 end, 10, "Rear Left MPCD Labels", "PB 10")
-F_15E:defineString("R_MPCDL_PBLABEL_11", function() 
-    return R_MPCDL_BUTTONS[11]
+F_15E:defineString("R_MPCDL_PBLABEL_11", function()
+	return R_MPCDL_BUTTONS[11]
 end, 10, "Rear Left MPCD Labels", "PB 11")
-F_15E:defineString("R_MPCDL_PBLABEL_12", function() 
-    return R_MPCDL_BUTTONS[12]
+F_15E:defineString("R_MPCDL_PBLABEL_12", function()
+	return R_MPCDL_BUTTONS[12]
 end, 10, "Rear Left MPCD Labels", "PB 12")
-F_15E:defineString("R_MPCDL_PBLABEL_13", function() 
-    return R_MPCDL_BUTTONS[13]
+F_15E:defineString("R_MPCDL_PBLABEL_13", function()
+	return R_MPCDL_BUTTONS[13]
 end, 10, "Rear Left MPCD Labels", "PB 13")
-F_15E:defineString("R_MPCDL_PBLABEL_14", function() 
-    return R_MPCDL_BUTTONS[14]
+F_15E:defineString("R_MPCDL_PBLABEL_14", function()
+	return R_MPCDL_BUTTONS[14]
 end, 10, "Rear Left MPCD Labels", "PB 14")
-F_15E:defineString("R_MPCDL_PBLABEL_15", function() 
-    return R_MPCDL_BUTTONS[15]
+F_15E:defineString("R_MPCDL_PBLABEL_15", function()
+	return R_MPCDL_BUTTONS[15]
 end, 10, "Rear Left MPCD Labels", "PB 15")
-F_15E:defineString("R_MPCDL_PBLABEL_16", function() 
-    return R_MPCDL_BUTTONS[16]
+F_15E:defineString("R_MPCDL_PBLABEL_16", function()
+	return R_MPCDL_BUTTONS[16]
 end, 10, "Rear Left MPCD Labels", "PB 16")
-F_15E:defineString("R_MPCDL_PBLABEL_17", function() 
-    return R_MPCDL_BUTTONS[17]
+F_15E:defineString("R_MPCDL_PBLABEL_17", function()
+	return R_MPCDL_BUTTONS[17]
 end, 10, "Rear Left MPCD Labels", "PB 17")
-F_15E:defineString("R_MPCDL_PBLABEL_18", function() 
-    return R_MPCDL_BUTTONS[18]
+F_15E:defineString("R_MPCDL_PBLABEL_18", function()
+	return R_MPCDL_BUTTONS[18]
 end, 10, "Rear Left MPCD Labels", "PB 18")
-F_15E:defineString("R_MPCDL_PBLABEL_19", function() 
-    return R_MPCDL_BUTTONS[19]
+F_15E:defineString("R_MPCDL_PBLABEL_19", function()
+	return R_MPCDL_BUTTONS[19]
 end, 10, "Rear Left MPCD Labels", "PB 19")
 F_15E:defineString("R_MPCDL_PBLABEL_20", function()
-    return R_MPCDL_BUTTONS[20]
+	return R_MPCDL_BUTTONS[20]
 end, 10, "Rear Left MPCD Labels", "PB 20")
 
 F_15E:defineString("R_MPDL_PBLABEL_01", function()
-    return R_MPDL_BUTTONS[1]
+	return R_MPDL_BUTTONS[1]
 end, 10, "Rear Left MPD Labels", "PB 01")
 F_15E:defineString("R_MPDL_PBLABEL_02", function()
-    return R_MPDL_BUTTONS[2]
+	return R_MPDL_BUTTONS[2]
 end, 10, "Rear Left MPD Labels", "PB 02")
 F_15E:defineString("R_MPDL_PBLABEL_03", function()
-    return R_MPDL_BUTTONS[3]
+	return R_MPDL_BUTTONS[3]
 end, 10, "Rear Left MPD Labels", "PB 03")
 F_15E:defineString("R_MPDL_PBLABEL_04", function()
-    return R_MPDL_BUTTONS[4]
+	return R_MPDL_BUTTONS[4]
 end, 10, "Rear Left MPD Labels", "PB 04")
 F_15E:defineString("R_MPDL_PBLABEL_05", function()
-    return R_MPDL_BUTTONS[5]
+	return R_MPDL_BUTTONS[5]
 end, 10, "Rear Left MPD Labels", "PB 05")
 F_15E:defineString("R_MPDL_PBLABEL_06", function()
-    return R_MPDL_BUTTONS[6]
+	return R_MPDL_BUTTONS[6]
 end, 10, "Rear Left MPD Labels", "PB 06")
 F_15E:defineString("R_MPDL_PBLABEL_07", function()
-    return R_MPDL_BUTTONS[7]
+	return R_MPDL_BUTTONS[7]
 end, 10, "Rear Left MPD Labels", "PB 07")
 F_15E:defineString("R_MPDL_PBLABEL_08", function()
-    return R_MPDL_BUTTONS[8]
+	return R_MPDL_BUTTONS[8]
 end, 10, "Rear Left MPD Labels", "PB 08")
 F_15E:defineString("R_MPDL_PBLABEL_09", function()
-    return R_MPDL_BUTTONS[9]
+	return R_MPDL_BUTTONS[9]
 end, 10, "Rear Left MPD Labels", "PB 09")
 F_15E:defineString("R_MPDL_PBLABEL_10", function()
-    return R_MPDL_BUTTONS[10]
+	return R_MPDL_BUTTONS[10]
 end, 10, "Rear Left MPD Labels", "PB 10")
 F_15E:defineString("R_MPDL_PBLABEL_11", function()
-    return R_MPDL_BUTTONS[11]
+	return R_MPDL_BUTTONS[11]
 end, 10, "Rear Left MPD Labels", "PB 11")
 F_15E:defineString("R_MPDL_PBLABEL_12", function()
-    return R_MPDL_BUTTONS[12]
+	return R_MPDL_BUTTONS[12]
 end, 10, "Rear Left MPD Labels", "PB 12")
 F_15E:defineString("R_MPDL_PBLABEL_13", function()
-    return R_MPDL_BUTTONS[13]
+	return R_MPDL_BUTTONS[13]
 end, 10, "Rear Left MPD Labels", "PB 13")
 F_15E:defineString("R_MPDL_PBLABEL_14", function()
-    return R_MPDL_BUTTONS[14]
+	return R_MPDL_BUTTONS[14]
 end, 10, "Rear Left MPD Labels", "PB 14")
 F_15E:defineString("R_MPDL_PBLABEL_15", function()
-    return R_MPDL_BUTTONS[15]
+	return R_MPDL_BUTTONS[15]
 end, 10, "Rear Left MPD Labels", "PB 15")
 F_15E:defineString("R_MPDL_PBLABEL_16", function()
-    return R_MPDL_BUTTONS[16]
+	return R_MPDL_BUTTONS[16]
 end, 10, "Rear Left MPD Labels", "PB 16")
 F_15E:defineString("R_MPDL_PBLABEL_17", function()
-    return R_MPDL_BUTTONS[17]
+	return R_MPDL_BUTTONS[17]
 end, 10, "Rear Left MPD Labels", "PB 17")
 F_15E:defineString("R_MPDL_PBLABEL_18", function()
-    return R_MPDL_BUTTONS[18]
+	return R_MPDL_BUTTONS[18]
 end, 10, "Rear Left MPD Labels", "PB 18")
 F_15E:defineString("R_MPDL_PBLABEL_19", function()
-    return R_MPDL_BUTTONS[19]
+	return R_MPDL_BUTTONS[19]
 end, 10, "Rear Left MPD Labels", "PB 19")
 F_15E:defineString("R_MPDL_PBLABEL_20", function()
-    return R_MPDL_BUTTONS[20]
+	return R_MPDL_BUTTONS[20]
 end, 10, "Rear Left MPD Labels", "PB 20")
 
 F_15E:defineString("R_MPDR_PBLABEL_01", function()
-    return R_MPDR_BUTTONS[1]
+	return R_MPDR_BUTTONS[1]
 end, 10, "Rear Right MPD Labels", "PB 01")
 F_15E:defineString("R_MPDR_PBLABEL_02", function()
-    return R_MPDR_BUTTONS[2]
+	return R_MPDR_BUTTONS[2]
 end, 10, "Rear Right MPD Labels", "PB 02")
 F_15E:defineString("R_MPDR_PBLABEL_03", function()
-    return R_MPDR_BUTTONS[3]
+	return R_MPDR_BUTTONS[3]
 end, 10, "Rear Right MPD Labels", "PB 03")
 F_15E:defineString("R_MPDR_PBLABEL_04", function()
-    return R_MPDR_BUTTONS[4]
+	return R_MPDR_BUTTONS[4]
 end, 10, "Rear Right MPD Labels", "PB 04")
 F_15E:defineString("R_MPDR_PBLABEL_05", function()
-    return R_MPDR_BUTTONS[5]
+	return R_MPDR_BUTTONS[5]
 end, 10, "Rear Right MPD Labels", "PB 05")
 F_15E:defineString("R_MPDR_PBLABEL_06", function()
-    return R_MPDR_BUTTONS[6]
+	return R_MPDR_BUTTONS[6]
 end, 10, "Rear Right MPD Labels", "PB 06")
 F_15E:defineString("R_MPDR_PBLABEL_07", function()
-    return R_MPDR_BUTTONS[7]
+	return R_MPDR_BUTTONS[7]
 end, 10, "Rear Right MPD Labels", "PB 07")
 F_15E:defineString("R_MPDR_PBLABEL_08", function()
-    return R_MPDR_BUTTONS[8]
+	return R_MPDR_BUTTONS[8]
 end, 10, "Rear Right MPD Labels", "PB 08")
 F_15E:defineString("R_MPDR_PBLABEL_09", function()
-    return R_MPDR_BUTTONS[9]
+	return R_MPDR_BUTTONS[9]
 end, 10, "Rear Right MPD Labels", "PB 09")
 F_15E:defineString("R_MPDR_PBLABEL_10", function()
-    return R_MPDR_BUTTONS[10]
+	return R_MPDR_BUTTONS[10]
 end, 10, "Rear Right MPD Labels", "PB 10")
 F_15E:defineString("R_MPDR_PBLABEL_11", function()
-    return R_MPDR_BUTTONS[11]
+	return R_MPDR_BUTTONS[11]
 end, 10, "Rear Right MPD Labels", "PB 11")
 F_15E:defineString("R_MPDR_PBLABEL_12", function()
-    return R_MPDR_BUTTONS[12]
+	return R_MPDR_BUTTONS[12]
 end, 10, "Rear Right MPD Labels", "PB 12")
 F_15E:defineString("R_MPDR_PBLABEL_13", function()
-    return R_MPDR_BUTTONS[13]
+	return R_MPDR_BUTTONS[13]
 end, 10, "Rear Right MPD Labels", "PB 13")
 F_15E:defineString("R_MPDR_PBLABEL_14", function()
-    return R_MPDR_BUTTONS[14]
+	return R_MPDR_BUTTONS[14]
 end, 10, "Rear Right MPD Labels", "PB 14")
 F_15E:defineString("R_MPDR_PBLABEL_15", function()
 	return R_MPDR_BUTTONS[15]
 end, 10, "Rear Right MPD Labels", "PB 15")
 F_15E:defineString("R_MPDR_PBLABEL_16", function()
-    return R_MPDR_BUTTONS[16]
+	return R_MPDR_BUTTONS[16]
 end, 10, "Rear Right MPD Labels", "PB 16")
 F_15E:defineString("R_MPDR_PBLABEL_17", function()
-    return R_MPDR_BUTTONS[17]
+	return R_MPDR_BUTTONS[17]
 end, 10, "Rear Right MPD Labels", "PB 17")
 F_15E:defineString("R_MPDR_PBLABEL_18", function()
-    return R_MPDR_BUTTONS[18]
+	return R_MPDR_BUTTONS[18]
 end, 10, "Rear Right MPD Labels", "PB 18")
 F_15E:defineString("R_MPDR_PBLABEL_19", function()
-    return R_MPDR_BUTTONS[19]
+	return R_MPDR_BUTTONS[19]
 end, 10, "Rear Right MPD Labels", "PB 19")
 F_15E:defineString("R_MPDR_PBLABEL_20", function()
-    return R_MPDR_BUTTONS[20]
+	return R_MPDR_BUTTONS[20]
 end, 10, "Rear Right MPD Labels", "PB 20")
 
 F_15E:defineString("R_MPCDR_PBLABEL_01", function()
-    return R_MPCDR_BUTTONS[1]
+	return R_MPCDR_BUTTONS[1]
 end, 10, "Rear Right MPCD Labels", "PB 01")
 F_15E:defineString("R_MPCDR_PBLABEL_02", function()
-    return R_MPCDR_BUTTONS[2]
+	return R_MPCDR_BUTTONS[2]
 end, 10, "Rear Right MPCD Labels", "PB 02")
 F_15E:defineString("R_MPCDR_PBLABEL_03", function()
-    return R_MPCDR_BUTTONS[3]
+	return R_MPCDR_BUTTONS[3]
 end, 10, "Rear Right MPCD Labels", "PB 03")
 F_15E:defineString("R_MPCDR_PBLABEL_04", function()
-    return R_MPCDR_BUTTONS[4]
+	return R_MPCDR_BUTTONS[4]
 end, 10, "Rear Right MPCD Labels", "PB 04")
 F_15E:defineString("R_MPCDR_PBLABEL_05", function()
-    return R_MPCDR_BUTTONS[5]
+	return R_MPCDR_BUTTONS[5]
 end, 10, "Rear Right MPCD Labels", "PB 05")
 F_15E:defineString("R_MPCDR_PBLABEL_06", function()
-    return R_MPCDR_BUTTONS[6]
+	return R_MPCDR_BUTTONS[6]
 end, 10, "Rear Right MPCD Labels", "PB 06")
 F_15E:defineString("R_MPCDR_PBLABEL_07", function()
-    return R_MPCDR_BUTTONS[7]
+	return R_MPCDR_BUTTONS[7]
 end, 10, "Rear Right MPCD Labels", "PB 07")
 F_15E:defineString("R_MPCDR_PBLABEL_08", function()
-    return R_MPCDR_BUTTONS[8]
+	return R_MPCDR_BUTTONS[8]
 end, 10, "Rear Right MPCD Labels", "PB 08")
 F_15E:defineString("R_MPCDR_PBLABEL_09", function()
-    return R_MPCDR_BUTTONS[9]
+	return R_MPCDR_BUTTONS[9]
 end, 10, "Rear Right MPCD Labels", "PB 09")
 F_15E:defineString("R_MPCDR_PBLABEL_10", function()
-    return R_MPCDR_BUTTONS[10]
+	return R_MPCDR_BUTTONS[10]
 end, 10, "Rear Right MPCD Labels", "PB 10")
 F_15E:defineString("R_MPCDR_PBLABEL_11", function()
-    return R_MPCDR_BUTTONS[11]
+	return R_MPCDR_BUTTONS[11]
 end, 10, "Rear Right MPCD Labels", "PB 11")
 F_15E:defineString("R_MPCDR_PBLABEL_12", function()
-    return R_MPCDR_BUTTONS[12]
+	return R_MPCDR_BUTTONS[12]
 end, 10, "Rear Right MPCD Labels", "PB 12")
 F_15E:defineString("R_MPCDR_PBLABEL_13", function()
-    return R_MPCDR_BUTTONS[13]
+	return R_MPCDR_BUTTONS[13]
 end, 10, "Rear Right MPCD Labels", "PB 13")
 F_15E:defineString("R_MPCDR_PBLABEL_14", function()
-    return R_MPCDR_BUTTONS[14]
+	return R_MPCDR_BUTTONS[14]
 end, 10, "Rear Right MPCD Labels", "PB 14")
 F_15E:defineString("R_MPCDR_PBLABEL_15", function()
-    return R_MPCDR_BUTTONS[15]
+	return R_MPCDR_BUTTONS[15]
 end, 10, "Rear Right MPCD Labels", "PB 15")
 F_15E:defineString("R_MPCDR_PBLABEL_16", function()
-    return R_MPCDR_BUTTONS[16]
+	return R_MPCDR_BUTTONS[16]
 end, 10, "Rear Right MPCD Labels", "PB 16")
 F_15E:defineString("R_MPCDR_PBLABEL_17", function()
-    return R_MPCDR_BUTTONS[17]
+	return R_MPCDR_BUTTONS[17]
 end, 10, "Rear Right MPCD Labels", "PB 17")
 F_15E:defineString("R_MPCDR_PBLABEL_18", function()
-    return R_MPCDR_BUTTONS[18]
+	return R_MPCDR_BUTTONS[18]
 end, 10, "Rear Right MPCD Labels", "PB 18")
 F_15E:defineString("R_MPCDR_PBLABEL_19", function()
-    return R_MPCDR_BUTTONS[19]
+	return R_MPCDR_BUTTONS[19]
 end, 10, "Rear Right MPCD Labels", "PB 19")
 F_15E:defineString("R_MPCDR_PBLABEL_20", function()
-    return R_MPCDR_BUTTONS[20]
+	return R_MPCDR_BUTTONS[20]
 end, 10, "Rear Right MPCD Labels", "PB 20")
 
 return F_15E

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
@@ -1178,14 +1178,14 @@ local F_MPCD_BUTTONS = {}
 local F_MPDR_BUTTONS = {}
 
 local function split(stringvalue, delimiter)
-    result = {};
+    local result = {};
     for match in (stringvalue .. delimiter):gmatch("(.-)" .. delimiter) do
         table.insert(result, match);
     end
     return result;
 end
 
---[[ types PB entries may be missing ; write entries only if they're nil,  "`" or "^" ; add child values with $ for splitting ; only acceptable suffix is _LABEL ; 
+--[[ types PB entries may be missing ; write entries only if they're nil,  "`" or "^" ; add child values with $ for splitting ; only acceptable suffix is _LABEL ;
 PB%d 							PB1 to PB9
 PB%d%d 							PB01 to PB20 or PB10 to PB20
 [random prefix]_PB%d%d_LABEL 	PACS_PB01-20_LABEL
@@ -1195,6 +1195,7 @@ PB%d%d_PB%d%d					PB12_PB13 for split on PB12 and PB13
 [any prefix]_PB%d%d				TFR_PB15 or TPOD_PB01 to TPOD_PB20 or SWPN_PB04
 PB%d%d_Value					is data begins 3 lines after "children are {" line
 PB%d%d%d%d						PB0405 for split between 04 and 05
+PB%d%d_%d%d						PB13_14 for split between 13 and 14
 ]]--
 
 local function parseMFDButtons(stringindication)
@@ -1205,7 +1206,6 @@ local function parseMFDButtons(stringindication)
 			local start = numline+1
 			local val = input[start]
 			local double = false
-			local done = false
 			if val then
 				local pos = string.match(val, "^PB(%d[%d]?)$")
 				if not pos then
@@ -1213,13 +1213,13 @@ local function parseMFDButtons(stringindication)
 					if not pos then
 						pos = string.match(val, "^PB(%d+)%-%d+$")
 						if not pos then
-							pos = string.match(val, "^PB(%d%d)[%d%d|_PB%d%d]+$")
+							pos = string.match(val, "^PB(%d%d)[%d%d|_PB%d%d|_%d%d]+$")
 							double = true
 						else
-						  	double = true
+							double = true
 						end
 					end
-			  	end
+				end
 				if pos then
 					local num = tonumber(pos)
 					local combine = ""
@@ -1240,12 +1240,11 @@ local function parseMFDButtons(stringindication)
 								end
 							else
 								break
-							end  
+							end
 						end
 					end
-					--print(num .. ", " .. val .. ": " .. combine)
 					if not double then
-						if not values[num] or string.match(values[num], "^[`%^]$") then
+						if (not values[num] or string.match(values[num], "^[`%^]$")) and combine ~= "" then
 							values[num] = combine
 						end
 					else
@@ -1255,17 +1254,18 @@ local function parseMFDButtons(stringindication)
 							values[num + (num>10 and 0 or 1)] = string.sub(combine, startnum, #combine)
 						end
 					end
-				end  
-			end 
+				end
+			end
 		end
 	end
 
 	for i = 1, 20 do
 		if not values[i] then
-			values[i] = "          the button ind"
+			values[i] = "          "
 		end
 	end
 	return values
+
 end
 
 F_15E:addExportHook(function()
@@ -1274,15 +1274,19 @@ F_15E:addExportHook(function()
 		return
 	end
 	F_MPDL_BUTTONS = parseMFDButtons(input)
+end)
 
-	input = list_indication(5)
+F_15E:addExportHook(function()
+	local input = list_indication(5)
 	if not input then
 		return
 	end
 	
 	F_MPCD_BUTTONS = parseMFDButtons(input)
+end)
 
-	input = list_indication(7)
+F_15E:addExportHook(function()
+	local input = list_indication(7)
 	if not input then
 		return
 	end
@@ -1290,189 +1294,188 @@ F_15E:addExportHook(function()
 	F_MPDR_BUTTONS = parseMFDButtons(input)
 end)
 
-F_15E:defineString("F_MPDL_PBLABEL_01", function() 
-    return F_MPDL_BUTTONS[1] 
-end, 10, "Front Left MPD Lables", "PB 01") 
-F_15E:defineString("F_MPDL_PBLABEL_02", function() 
-    return F_MPDL_BUTTONS[2] 
-end, 10, "Front Left MPD Lables", "PB 02") 
-F_15E:defineString("F_MPDL_PBLABEL_03", function() 
-    return F_MPDL_BUTTONS[3] 
-end, 10, "Front Left MPD Lables", "PB 03") 
-F_15E:defineString("F_MPDL_PBLABEL_04", function() 
-    return F_MPDL_BUTTONS[4] 
-end, 10, "Front Left MPD Lables", "PB 04") 
-F_15E:defineString("F_MPDL_PBLABEL_05", function() 
-    return F_MPDL_BUTTONS[5] 
-end, 10, "Front Left MPD Lables", "PB 05") 
-F_15E:defineString("F_MPDL_PBLABEL_06", function() 
-    return F_MPDL_BUTTONS[6] 
-end, 10, "Front Left MPD Lables", "PB 06") 
-F_15E:defineString("F_MPDL_PBLABEL_07", function() 
-    return F_MPDL_BUTTONS[7] 
-end, 10, "Front Left MPD Lables", "PB 07") 
-F_15E:defineString("F_MPDL_PBLABEL_08", function() 
-    return F_MPDL_BUTTONS[8] 
-end, 10, "Front Left MPD Lables", "PB 08") 
-F_15E:defineString("F_MPDL_PBLABEL_09", function() 
-    return F_MPDL_BUTTONS[9] 
-end, 10, "Front Left MPD Lables", "PB 09") 
-F_15E:defineString("F_MPDL_PBLABEL_10", function() 
-    return F_MPDL_BUTTONS[10] 
-end, 10, "Front Left MPD Lables", "PB 10") 
-F_15E:defineString("F_MPDL_PBLABEL_11", function() 
-    return F_MPDL_BUTTONS[11] 
-end, 10, "Front Left MPD Lables", "PB 11") 
-F_15E:defineString("F_MPDL_PBLABEL_12", function() 
-    return F_MPDL_BUTTONS[12] 
-end, 10, "Front Left MPD Lables", "PB 12") 
-F_15E:defineString("F_MPDL_PBLABEL_13", function() 
-    return F_MPDL_BUTTONS[13] 
-end, 10, "Front Left MPD Lables", "PB 13") 
-F_15E:defineString("F_MPDL_PBLABEL_14", function() 
-    return F_MPDL_BUTTONS[14] 
-end, 10, "Front Left MPD Lables", "PB 14") 
-F_15E:defineString("F_MPDL_PBLABEL_15", function() 
-    return F_MPDL_BUTTONS[15] 
-end, 10, "Front Left MPD Lables", "PB 15") 
-F_15E:defineString("F_MPDL_PBLABEL_16", function() 
-    return F_MPDL_BUTTONS[16] 
-end, 10, "Front Left MPD Lables", "PB 16") 
-F_15E:defineString("F_MPDL_PBLABEL_17", function() 
-    return F_MPDL_BUTTONS[17] 
-end, 10, "Front Left MPD Lables", "PB 17") 
-F_15E:defineString("F_MPDL_PBLABEL_18", function() 
-    return F_MPDL_BUTTONS[18] 
-end, 10, "Front Left MPD Lables", "PB 18") 
-F_15E:defineString("F_MPDL_PBLABEL_19", function() 
-    return F_MPDL_BUTTONS[19] 
-end, 10, "Front Left MPD Lables", "PB 19") 
-F_15E:defineString("F_MPDL_PBLABEL_20", function() 
-    return F_MPDL_BUTTONS[20] 
-end, 10, "Front Left MPD Lables", "PB 20")
+F_15E:defineString("F_MPDL_PBLABEL_01", function()
+    return F_MPDL_BUTTONS[1]
+end, 10, "Front Left MPD Labels", "PB 01")
+F_15E:defineString("F_MPDL_PBLABEL_02", function()
+    return F_MPDL_BUTTONS[2]
+end, 10, "Front Left MPD Labels", "PB 02")
+F_15E:defineString("F_MPDL_PBLABEL_03", function()
+    return F_MPDL_BUTTONS[3]
+end, 10, "Front Left MPD Labels", "PB 03")
+F_15E:defineString("F_MPDL_PBLABEL_04", function()
+    return F_MPDL_BUTTONS[4]
+end, 10, "Front Left MPD Labels", "PB 04")
+F_15E:defineString("F_MPDL_PBLABEL_05", function()
+    return F_MPDL_BUTTONS[5]
+end, 10, "Front Left MPD Labels", "PB 05")
+F_15E:defineString("F_MPDL_PBLABEL_06", function()
+    return F_MPDL_BUTTONS[6]
+end, 10, "Front Left MPD Labels", "PB 06")
+F_15E:defineString("F_MPDL_PBLABEL_07", function()
+    return F_MPDL_BUTTONS[7]
+end, 10, "Front Left MPD Labels", "PB 07")
+F_15E:defineString("F_MPDL_PBLABEL_08", function()
+    return F_MPDL_BUTTONS[8]
+end, 10, "Front Left MPD Labels", "PB 08")
+F_15E:defineString("F_MPDL_PBLABEL_09", function()
+    return F_MPDL_BUTTONS[9]
+end, 10, "Front Left MPD Labels", "PB 09")
+F_15E:defineString("F_MPDL_PBLABEL_10", function()
+    return F_MPDL_BUTTONS[10]
+end, 10, "Front Left MPD Labels", "PB 10")
+F_15E:defineString("F_MPDL_PBLABEL_11", function()
+    return F_MPDL_BUTTONS[11]
+end, 10, "Front Left MPD Labels", "PB 11")
+F_15E:defineString("F_MPDL_PBLABEL_12", function()
+    return F_MPDL_BUTTONS[12]
+end, 10, "Front Left MPD Labels", "PB 12")
+F_15E:defineString("F_MPDL_PBLABEL_13", function()
+    return F_MPDL_BUTTONS[13]
+end, 10, "Front Left MPD Labels", "PB 13")
+F_15E:defineString("F_MPDL_PBLABEL_14", function()
+    return F_MPDL_BUTTONS[14]
+end, 10, "Front Left MPD Labels", "PB 14")
+F_15E:defineString("F_MPDL_PBLABEL_15", function()
+    return F_MPDL_BUTTONS[15]
+end, 10, "Front Left MPD Labels", "PB 15")
+F_15E:defineString("F_MPDL_PBLABEL_16", function()
+    return F_MPDL_BUTTONS[16]
+end, 10, "Front Left MPD Labels", "PB 16")
+F_15E:defineString("F_MPDL_PBLABEL_17", function()
+    return F_MPDL_BUTTONS[17]
+end, 10, "Front Left MPD Labels", "PB 17")
+F_15E:defineString("F_MPDL_PBLABEL_18", function()
+    return F_MPDL_BUTTONS[18]
+end, 10, "Front Left MPD Labels", "PB 18")
+F_15E:defineString("F_MPDL_PBLABEL_19", function()
+    return F_MPDL_BUTTONS[19]
+end, 10, "Front Left MPD Labels", "PB 19")
+F_15E:defineString("F_MPDL_PBLABEL_20", function()
+    return F_MPDL_BUTTONS[20]
+end, 10, "Front Left MPD Labels", "PB 20")
 
-F_15E:defineString("F_MPCD_PBLABEL_01", function() 
-    return F_MPCD_BUTTONS[1] 
-end, 10, "Front Center MPCD Lables", "PB 01") 
-F_15E:defineString("F_MPCD_PBLABEL_02", function() 
-    return F_MPCD_BUTTONS[2] 
-end, 10, "Front Center MPCD Lables", "PB 02") 
-F_15E:defineString("F_MPCD_PBLABEL_03", function() 
-    return F_MPCD_BUTTONS[3] 
-end, 10, "Front Center MPCD Lables", "PB 03") 
-F_15E:defineString("F_MPCD_PBLABEL_04", function() 
-    return F_MPCD_BUTTONS[4] 
-end, 10, "Front Center MPCD Lables", "PB 04") 
-F_15E:defineString("F_MPCD_PBLABEL_05", function() 
-    return F_MPCD_BUTTONS[5] 
-end, 10, "Front Center MPCD Lables", "PB 05") 
-F_15E:defineString("F_MPCD_PBLABEL_06", function() 
-    return F_MPCD_BUTTONS[6] 
-end, 10, "Front Center MPCD Lables", "PB 06") 
-F_15E:defineString("F_MPCD_PBLABEL_07", function() 
-    return F_MPCD_BUTTONS[7] 
-end, 10, "Front Center MPCD Lables", "PB 07") 
-F_15E:defineString("F_MPCD_PBLABEL_08", function() 
-    return F_MPCD_BUTTONS[8] 
-end, 10, "Front Center MPCD Lables", "PB 08") 
-F_15E:defineString("F_MPCD_PBLABEL_09", function() 
-    return F_MPCD_BUTTONS[9] 
-end, 10, "Front Center MPCD Lables", "PB 09") 
-F_15E:defineString("F_MPCD_PBLABEL_10", function() 
-    return F_MPCD_BUTTONS[10] 
-end, 10, "Front Center MPCD Lables", "PB 10") 
-F_15E:defineString("F_MPCD_PBLABEL_11", function() 
-    return F_MPCD_BUTTONS[11] 
-end, 10, "Front Center MPCD Lables", "PB 11") 
-F_15E:defineString("F_MPCD_PBLABEL_12", function() 
-    return F_MPCD_BUTTONS[12] 
-end, 10, "Front Center MPCD Lables", "PB 12") 
-F_15E:defineString("F_MPCD_PBLABEL_13", function() 
-    return F_MPCD_BUTTONS[13] 
-end, 10, "Front Center MPCD Lables", "PB 13") 
-F_15E:defineString("F_MPCD_PBLABEL_14", function() 
-    return F_MPCD_BUTTONS[14] 
-end, 10, "Front Center MPCD Lables", "PB 14") 
-F_15E:defineString("F_MPCD_PBLABEL_15", function() 
-    return F_MPCD_BUTTONS[15] 
-end, 10, "Front Center MPCD Lables", "PB 15") 
-F_15E:defineString("F_MPCD_PBLABEL_16", function() 
-    return F_MPCD_BUTTONS[16] 
-end, 10, "Front Center MPCD Lables", "PB 16") 
-F_15E:defineString("F_MPCD_PBLABEL_17", function() 
-    return F_MPCD_BUTTONS[17] 
-end, 10, "Front Center MPCD Lables", "PB 17") 
-F_15E:defineString("F_MPCD_PBLABEL_18", function() 
-    return F_MPCD_BUTTONS[18] 
-end, 10, "Front Center MPCD Lables", "PB 18") 
-F_15E:defineString("F_MPCD_PBLABEL_19", function() 
-    return F_MPCD_BUTTONS[19] 
-end, 10, "Front Center MPCD Lables", "PB 19") 
-F_15E:defineString("F_MPCD_PBLABEL_20", function() 
-    return F_MPCD_BUTTONS[20] 
-end, 10, "Front Center MPCD Lables", "PB 20") 
+F_15E:defineString("F_MPCD_PBLABEL_01", function()
+    return F_MPCD_BUTTONS[1]
+end, 10, "Front Center MPCD Labels", "PB 01")
+F_15E:defineString("F_MPCD_PBLABEL_02", function()
+    return F_MPCD_BUTTONS[2]
+end, 10, "Front Center MPCD Labels", "PB 02")
+F_15E:defineString("F_MPCD_PBLABEL_03", function()
+    return F_MPCD_BUTTONS[3]
+end, 10, "Front Center MPCD Labels", "PB 03")
+F_15E:defineString("F_MPCD_PBLABEL_04", function()
+    return F_MPCD_BUTTONS[4]
+end, 10, "Front Center MPCD Labels", "PB 04")
+F_15E:defineString("F_MPCD_PBLABEL_05", function()
+    return F_MPCD_BUTTONS[5]
+end, 10, "Front Center MPCD Labels", "PB 05")
+F_15E:defineString("F_MPCD_PBLABEL_06", function()
+    return F_MPCD_BUTTONS[6]
+end, 10, "Front Center MPCD Labels", "PB 06")
+F_15E:defineString("F_MPCD_PBLABEL_07", function()
+    return F_MPCD_BUTTONS[7]
+end, 10, "Front Center MPCD Labels", "PB 07")
+F_15E:defineString("F_MPCD_PBLABEL_08", function()
+    return F_MPCD_BUTTONS[8]
+end, 10, "Front Center MPCD Labels", "PB 08")
+F_15E:defineString("F_MPCD_PBLABEL_09", function()
+    return F_MPCD_BUTTONS[9]
+end, 10, "Front Center MPCD Labels", "PB 09")
+F_15E:defineString("F_MPCD_PBLABEL_10", function()
+    return F_MPCD_BUTTONS[10]
+end, 10, "Front Center MPCD Labels", "PB 10")
+F_15E:defineString("F_MPCD_PBLABEL_11", function()
+    return F_MPCD_BUTTONS[11]
+end, 10, "Front Center MPCD Labels", "PB 11")
+F_15E:defineString("F_MPCD_PBLABEL_12", function()
+    return F_MPCD_BUTTONS[12]
+end, 10, "Front Center MPCD Labels", "PB 12")
+F_15E:defineString("F_MPCD_PBLABEL_13", function()
+    return F_MPCD_BUTTONS[13]
+end, 10, "Front Center MPCD Labels", "PB 13")
+F_15E:defineString("F_MPCD_PBLABEL_14", function()
+    return F_MPCD_BUTTONS[14]
+end, 10, "Front Center MPCD Labels", "PB 14")
+F_15E:defineString("F_MPCD_PBLABEL_15", function()
+    return F_MPCD_BUTTONS[15]
+end, 10, "Front Center MPCD Labels", "PB 15")
+F_15E:defineString("F_MPCD_PBLABEL_16", function()
+    return F_MPCD_BUTTONS[16]
+end, 10, "Front Center MPCD Labels", "PB 16")
+F_15E:defineString("F_MPCD_PBLABEL_17", function()
+    return F_MPCD_BUTTONS[17]
+end, 10, "Front Center MPCD Labels", "PB 17")
+F_15E:defineString("F_MPCD_PBLABEL_18", function()
+    return F_MPCD_BUTTONS[18]
+end, 10, "Front Center MPCD Labels", "PB 18")
+F_15E:defineString("F_MPCD_PBLABEL_19", function()
+    return F_MPCD_BUTTONS[19]
+end, 10, "Front Center MPCD Labels", "PB 19")
+F_15E:defineString("F_MPCD_PBLABEL_20", function()
+    return F_MPCD_BUTTONS[20]
+end, 10, "Front Center MPCD Labels", "PB 20")
 
-F_15E:defineString("F_MPDR_PBLABEL_01", function() 
-    return F_MPDR_BUTTONS[1] 
-end, 10, "Front Right MPD Lables", "PB 01") 
-F_15E:defineString("F_MPDR_PBLABEL_02", function() 
-    return F_MPDR_BUTTONS[2] 
-end, 10, "Front Right MPD Lables", "PB 02") 
-F_15E:defineString("F_MPDR_PBLABEL_03", function() 
-    return F_MPDR_BUTTONS[3] 
-end, 10, "Front Right MPD Lables", "PB 03") 
-F_15E:defineString("F_MPDR_PBLABEL_04", function() 
-    return F_MPDR_BUTTONS[4] 
-end, 10, "Front Right MPD Lables", "PB 04") 
-F_15E:defineString("F_MPDR_PBLABEL_05", function() 
-    return F_MPDR_BUTTONS[5] 
-end, 10, "Front Right MPD Lables", "PB 05") 
-F_15E:defineString("F_MPDR_PBLABEL_06", function() 
-    return F_MPDR_BUTTONS[6] 
-end, 10, "Front Right MPD Lables", "PB 06") 
-F_15E:defineString("F_MPDR_PBLABEL_07", function() 
-    return F_MPDR_BUTTONS[7] 
-end, 10, "Front Right MPD Lables", "PB 07") 
-F_15E:defineString("F_MPDR_PBLABEL_08", function() 
-    return F_MPDR_BUTTONS[8] 
-end, 10, "Front Right MPD Lables", "PB 08") 
-F_15E:defineString("F_MPDR_PBLABEL_09", function() 
-    return F_MPDR_BUTTONS[9] 
-end, 10, "Front Right MPD Lables", "PB 09") 
-F_15E:defineString("F_MPDR_PBLABEL_10", function() 
-    return F_MPDR_BUTTONS[10] 
-end, 10, "Front Right MPD Lables", "PB 10") 
-F_15E:defineString("F_MPDR_PBLABEL_11", function() 
-    return F_MPDR_BUTTONS[11] 
-end, 10, "Front Right MPD Lables", "PB 11") 
-F_15E:defineString("F_MPDR_PBLABEL_12", function() 
-    return F_MPDR_BUTTONS[12] 
-end, 10, "Front Right MPD Lables", "PB 12") 
-F_15E:defineString("F_MPDR_PBLABEL_13", function() 
-    return F_MPDR_BUTTONS[13] 
-end, 10, "Front Right MPD Lables", "PB 13") 
-F_15E:defineString("F_MPDR_PBLABEL_14", function() 
-    return F_MPDR_BUTTONS[14] 
-end, 10, "Front Right MPD Lables", "PB 14") 
-F_15E:defineString("F_MPDR_PBLABEL_15", function() 
-    return F_MPDR_BUTTONS[15] 
-end, 10, "Front Right MPD Lables", "PB 15") 
-F_15E:defineString("F_MPDR_PBLABEL_16", function() 
-    return F_MPDR_BUTTONS[16] 
-end, 10, "Front Right MPD Lables", "PB 16") 
-F_15E:defineString("F_MPDR_PBLABEL_17", function() 
-    return F_MPDR_BUTTONS[17] 
-end, 10, "Front Right MPD Lables", "PB 17") 
-F_15E:defineString("F_MPDR_PBLABEL_18", function() 
-    return F_MPDR_BUTTONS[18] 
-end, 10, "Front Right MPD Lables", "PB 18") 
-F_15E:defineString("F_MPDR_PBLABEL_19", function() 
-    return F_MPDR_BUTTONS[19] 
-end, 10, "Front Right MPD Lables", "PB 19") 
-F_15E:defineString("F_MPDR_PBLABEL_20", function() 
-    return F_MPDR_BUTTONS[20] 
-end, 10, "Front Right MPD Lables", "PB 20")
-
+F_15E:defineString("F_MPDR_PBLABEL_01", function()
+    return F_MPDR_BUTTONS[1]
+end, 10, "Front Right MPD Labels", "PB 01")
+F_15E:defineString("F_MPDR_PBLABEL_02", function()
+    return F_MPDR_BUTTONS[2]
+end, 10, "Front Right MPD Labels", "PB 02")
+F_15E:defineString("F_MPDR_PBLABEL_03", function()
+    return F_MPDR_BUTTONS[3]
+end, 10, "Front Right MPD Labels", "PB 03")
+F_15E:defineString("F_MPDR_PBLABEL_04", function()
+    return F_MPDR_BUTTONS[4]
+end, 10, "Front Right MPD Labels", "PB 04")
+F_15E:defineString("F_MPDR_PBLABEL_05", function()
+    return F_MPDR_BUTTONS[5]
+end, 10, "Front Right MPD Labels", "PB 05")
+F_15E:defineString("F_MPDR_PBLABEL_06", function()
+    return F_MPDR_BUTTONS[6]
+end, 10, "Front Right MPD Labels", "PB 06")
+F_15E:defineString("F_MPDR_PBLABEL_07", function()
+    return F_MPDR_BUTTONS[7]
+end, 10, "Front Right MPD Labels", "PB 07")
+F_15E:defineString("F_MPDR_PBLABEL_08", function()
+    return F_MPDR_BUTTONS[8]
+end, 10, "Front Right MPD Labels", "PB 08")
+F_15E:defineString("F_MPDR_PBLABEL_09", function()
+    return F_MPDR_BUTTONS[9]
+end, 10, "Front Right MPD Labels", "PB 09")
+F_15E:defineString("F_MPDR_PBLABEL_10", function()
+    return F_MPDR_BUTTONS[10]
+end, 10, "Front Right MPD Labels", "PB 10")
+F_15E:defineString("F_MPDR_PBLABEL_11", function()
+    return F_MPDR_BUTTONS[11]
+end, 10, "Front Right MPD Labels", "PB 11")
+F_15E:defineString("F_MPDR_PBLABEL_12", function()
+    return F_MPDR_BUTTONS[12]
+end, 10, "Front Right MPD Labels", "PB 12")
+F_15E:defineString("F_MPDR_PBLABEL_13", function()
+    return F_MPDR_BUTTONS[13]
+end, 10, "Front Right MPD Labels", "PB 13")
+F_15E:defineString("F_MPDR_PBLABEL_14", function()
+    return F_MPDR_BUTTONS[14]
+end, 10, "Front Right MPD Labels", "PB 14")
+F_15E:defineString("F_MPDR_PBLABEL_15", function()
+    return F_MPDR_BUTTONS[15]
+end, 10, "Front Right MPD Labels", "PB 15")
+F_15E:defineString("F_MPDR_PBLABEL_16", function()
+    return F_MPDR_BUTTONS[16]
+end, 10, "Front Right MPD Labels", "PB 16")
+F_15E:defineString("F_MPDR_PBLABEL_17", function()
+    return F_MPDR_BUTTONS[17]
+end, 10, "Front Right MPD Labels", "PB 17")
+F_15E:defineString("F_MPDR_PBLABEL_18", function()
+    return F_MPDR_BUTTONS[18]
+end, 10, "Front Right MPD Labels", "PB 18")
+F_15E:defineString("F_MPDR_PBLABEL_19", function()
+    return F_MPDR_BUTTONS[19]
+end, 10, "Front Right MPD Labels", "PB 19")
+F_15E:defineString("F_MPDR_PBLABEL_20", function()
+    return F_MPDR_BUTTONS[20]
+end, 10, "Front Right MPD Labels", "PB 20")
 
 local R_MPCDL_BUTTONS = {}
 
@@ -1482,29 +1485,34 @@ local R_MPDR_BUTTONS = {}
 
 local R_MPCDR_BUTTONS = {}
 
-
 F_15E:addExportHook(function()
 	local input = list_indication(10)
 	if not input then
 		return
 	end
 	R_MPCDL_BUTTONS = parseMFDButtons(input)
+end)
 
-	input = list_indication(12)
+F_15E:addExportHook(function()
+	local input = list_indication(12)
 	if not input then
 		return
 	end
 	
 	R_MPDL_BUTTONS = parseMFDButtons(input)
+end)
 
-	input = list_indication(14)
+F_15E:addExportHook(function()
+	local input = list_indication(14)
 	if not input then
 		return
 	end
 	
 	R_MPDR_BUTTONS = parseMFDButtons(input)
+end)
 
-	input = list_indication(16)
+F_15E:addExportHook(function()
+	local input = list_indication(16)
 	if not input then
 		return
 	end
@@ -1512,249 +1520,248 @@ F_15E:addExportHook(function()
 	R_MPCDR_BUTTONS = parseMFDButtons(input)
 end)
 
-F_15E:defineString("R_MPCDL_PBLABEL_01", function()  
-    return R_MPCDL_BUTTONS[1]  
-end, 10, "Rear Left MPCD Lables", "PB 01")
-F_15E:defineString("R_MPCDL_PBLABEL_02", function()  
-    return R_MPCDL_BUTTONS[2]  
-end, 10, "Rear Left MPCD Lables", "PB 02")
-F_15E:defineString("R_MPCDL_PBLABEL_03", function()  
-    return R_MPCDL_BUTTONS[3]  
-end, 10, "Rear Left MPCD Lables", "PB 03")
-F_15E:defineString("R_MPCDL_PBLABEL_04", function()  
-    return R_MPCDL_BUTTONS[4]  
-end, 10, "Rear Left MPCD Lables", "PB 04")
-F_15E:defineString("R_MPCDL_PBLABEL_05", function()  
-    return R_MPCDL_BUTTONS[5]  
-end, 10, "Rear Left MPCD Lables", "PB 05")
-F_15E:defineString("R_MPCDL_PBLABEL_06", function()  
-    return R_MPCDL_BUTTONS[6]  
-end, 10, "Rear Left MPCD Lables", "PB 06")
-F_15E:defineString("R_MPCDL_PBLABEL_07", function()  
-    return R_MPCDL_BUTTONS[7]  
-end, 10, "Rear Left MPCD Lables", "PB 07")
-F_15E:defineString("R_MPCDL_PBLABEL_08", function()  
-    return R_MPCDL_BUTTONS[8]  
-end, 10, "Rear Left MPCD Lables", "PB 08")
-F_15E:defineString("R_MPCDL_PBLABEL_09", function()  
-    return R_MPCDL_BUTTONS[9]  
-end, 10, "Rear Left MPCD Lables", "PB 9")
-F_15E:defineString("R_MPCDL_PBLABEL_10", function()  
-    return R_MPCDL_BUTTONS[10]  
-end, 10, "Rear Left MPCD Lables", "PB 10")
-F_15E:defineString("R_MPCDL_PBLABEL_11", function()  
-    return R_MPCDL_BUTTONS[11]  
-end, 10, "Rear Left MPCD Lables", "PB 11")
-F_15E:defineString("R_MPCDL_PBLABEL_12", function()  
-    return R_MPCDL_BUTTONS[12]  
-end, 10, "Rear Left MPCD Lables", "PB 12")
-F_15E:defineString("R_MPCDL_PBLABEL_13", function()  
-    return R_MPCDL_BUTTONS[13]  
-end, 10, "Rear Left MPCD Lables", "PB 13")
-F_15E:defineString("R_MPCDL_PBLABEL_14", function()  
-    return R_MPCDL_BUTTONS[14]  
-end, 10, "Rear Left MPCD Lables", "PB 14")
-F_15E:defineString("R_MPCDL_PBLABEL_15", function()  
-    return R_MPCDL_BUTTONS[15]  
-end, 10, "Rear Left MPCD Lables", "PB 15")
-F_15E:defineString("R_MPCDL_PBLABEL_16", function()  
-    return R_MPCDL_BUTTONS[16]  
-end, 10, "Rear Left MPCD Lables", "PB 16")
-F_15E:defineString("R_MPCDL_PBLABEL_17", function()  
-    return R_MPCDL_BUTTONS[17]  
-end, 10, "Rear Left MPCD Lables", "PB 17")
-F_15E:defineString("R_MPCDL_PBLABEL_18", function()  
-    return R_MPCDL_BUTTONS[18]  
-end, 10, "Rear Left MPCD Lables", "PB 18")
-F_15E:defineString("R_MPCDL_PBLABEL_19", function()  
-    return R_MPCDL_BUTTONS[19]  
-end, 10, "Rear Left MPCD Lables", "PB 19")
-F_15E:defineString("R_MPCDL_PBLABEL_20", function()  
-    return R_MPCDL_BUTTONS[20]  
-end, 10, "Rear Left MPCD Lables", "PB 20")
+F_15E:defineString("R_MPCDL_PBLABEL_01", function() 
+    return R_MPCDL_BUTTONS[1]
+end, 10, "Rear Left MPCD Labels", "PB 01")
+F_15E:defineString("R_MPCDL_PBLABEL_02", function() 
+    return R_MPCDL_BUTTONS[2]
+end, 10, "Rear Left MPCD Labels", "PB 02")
+F_15E:defineString("R_MPCDL_PBLABEL_03", function()
+    return R_MPCDL_BUTTONS[3]
+end, 10, "Rear Left MPCD Labels", "PB 03")
+F_15E:defineString("R_MPCDL_PBLABEL_04", function() 
+    return R_MPCDL_BUTTONS[4]
+end, 10, "Rear Left MPCD Labels", "PB 04")
+F_15E:defineString("R_MPCDL_PBLABEL_05", function() 
+    return R_MPCDL_BUTTONS[5]
+end, 10, "Rear Left MPCD Labels", "PB 05")
+F_15E:defineString("R_MPCDL_PBLABEL_06", function() 
+    return R_MPCDL_BUTTONS[6]
+end, 10, "Rear Left MPCD Labels", "PB 06")
+F_15E:defineString("R_MPCDL_PBLABEL_07", function() 
+    return R_MPCDL_BUTTONS[7]
+end, 10, "Rear Left MPCD Labels", "PB 07")
+F_15E:defineString("R_MPCDL_PBLABEL_08", function() 
+    return R_MPCDL_BUTTONS[8]
+end, 10, "Rear Left MPCD Labels", "PB 08")
+F_15E:defineString("R_MPCDL_PBLABEL_09", function() 
+    return R_MPCDL_BUTTONS[9]
+end, 10, "Rear Left MPCD Labels", "PB 9")
+F_15E:defineString("R_MPCDL_PBLABEL_10", function() 
+    return R_MPCDL_BUTTONS[10]
+end, 10, "Rear Left MPCD Labels", "PB 10")
+F_15E:defineString("R_MPCDL_PBLABEL_11", function() 
+    return R_MPCDL_BUTTONS[11]
+end, 10, "Rear Left MPCD Labels", "PB 11")
+F_15E:defineString("R_MPCDL_PBLABEL_12", function() 
+    return R_MPCDL_BUTTONS[12]
+end, 10, "Rear Left MPCD Labels", "PB 12")
+F_15E:defineString("R_MPCDL_PBLABEL_13", function() 
+    return R_MPCDL_BUTTONS[13]
+end, 10, "Rear Left MPCD Labels", "PB 13")
+F_15E:defineString("R_MPCDL_PBLABEL_14", function() 
+    return R_MPCDL_BUTTONS[14]
+end, 10, "Rear Left MPCD Labels", "PB 14")
+F_15E:defineString("R_MPCDL_PBLABEL_15", function() 
+    return R_MPCDL_BUTTONS[15]
+end, 10, "Rear Left MPCD Labels", "PB 15")
+F_15E:defineString("R_MPCDL_PBLABEL_16", function() 
+    return R_MPCDL_BUTTONS[16]
+end, 10, "Rear Left MPCD Labels", "PB 16")
+F_15E:defineString("R_MPCDL_PBLABEL_17", function() 
+    return R_MPCDL_BUTTONS[17]
+end, 10, "Rear Left MPCD Labels", "PB 17")
+F_15E:defineString("R_MPCDL_PBLABEL_18", function() 
+    return R_MPCDL_BUTTONS[18]
+end, 10, "Rear Left MPCD Labels", "PB 18")
+F_15E:defineString("R_MPCDL_PBLABEL_19", function() 
+    return R_MPCDL_BUTTONS[19]
+end, 10, "Rear Left MPCD Labels", "PB 19")
+F_15E:defineString("R_MPCDL_PBLABEL_20", function()
+    return R_MPCDL_BUTTONS[20]
+end, 10, "Rear Left MPCD Labels", "PB 20")
 
-F_15E:defineString("R_MPDL_PBLABEL_01", function()  
-    return R_MPDL_BUTTONS[1]  
-end, 10, "Rear Left MPD Lables", "PB 01")
-F_15E:defineString("R_MPDL_PBLABEL_02", function()  
-    return R_MPDL_BUTTONS[2]  
-end, 10, "Rear Left MPD Lables", "PB 02")
-F_15E:defineString("R_MPDL_PBLABEL_03", function()  
-    return R_MPDL_BUTTONS[3]  
-end, 10, "Rear Left MPD Lables", "PB 03")
-F_15E:defineString("R_MPDL_PBLABEL_04", function()  
-    return R_MPDL_BUTTONS[4]  
-end, 10, "Rear Left MPD Lables", "PB 04")
-F_15E:defineString("R_MPDL_PBLABEL_05", function()  
-    return R_MPDL_BUTTONS[5]  
-end, 10, "Rear Left MPD Lables", "PB 05")
-F_15E:defineString("R_MPDL_PBLABEL_06", function()  
-    return R_MPDL_BUTTONS[6]  
-end, 10, "Rear Left MPD Lables", "PB 06")
-F_15E:defineString("R_MPDL_PBLABEL_07", function()  
-    return R_MPDL_BUTTONS[7]  
-end, 10, "Rear Left MPD Lables", "PB 07")
-F_15E:defineString("R_MPDL_PBLABEL_08", function()  
-    return R_MPDL_BUTTONS[8]  
-end, 10, "Rear Left MPD Lables", "PB 08")
-F_15E:defineString("R_MPDL_PBLABEL_09", function()  
-    return R_MPDL_BUTTONS[9]  
-end, 10, "Rear Left MPD Lables", "PB 09")
-F_15E:defineString("R_MPDL_PBLABEL_10", function()  
-    return R_MPDL_BUTTONS[10]  
-end, 10, "Rear Left MPD Lables", "PB 10")
-F_15E:defineString("R_MPDL_PBLABEL_11", function()  
-    return R_MPDL_BUTTONS[11]  
-end, 10, "Rear Left MPD Lables", "PB 11")
-F_15E:defineString("R_MPDL_PBLABEL_12", function()  
-    return R_MPDL_BUTTONS[12]  
-end, 10, "Rear Left MPD Lables", "PB 12")
-F_15E:defineString("R_MPDL_PBLABEL_13", function()  
-    return R_MPDL_BUTTONS[13]  
-end, 10, "Rear Left MPD Lables", "PB 13")
-F_15E:defineString("R_MPDL_PBLABEL_14", function()  
-    return R_MPDL_BUTTONS[14]  
-end, 10, "Rear Left MPD Lables", "PB 14")
-F_15E:defineString("R_MPDL_PBLABEL_15", function()  
-    return R_MPDL_BUTTONS[15]  
-end, 10, "Rear Left MPD Lables", "PB 15")
-F_15E:defineString("R_MPDL_PBLABEL_16", function()  
-    return R_MPDL_BUTTONS[16]  
-end, 10, "Rear Left MPD Lables", "PB 16")
-F_15E:defineString("R_MPDL_PBLABEL_17", function()  
-    return R_MPDL_BUTTONS[17]  
-end, 10, "Rear Left MPD Lables", "PB 17")
-F_15E:defineString("R_MPDL_PBLABEL_18", function()  
-    return R_MPDL_BUTTONS[18]  
-end, 10, "Rear Left MPD Lables", "PB 18")
-F_15E:defineString("R_MPDL_PBLABEL_19", function()  
-    return R_MPDL_BUTTONS[19]  
-end, 10, "Rear Left MPD Lables", "PB 19")
-F_15E:defineString("R_MPDL_PBLABEL_20", function()  
-    return R_MPDL_BUTTONS[20]  
-end, 10, "Rear Left MPD Lables", "PB 20")
+F_15E:defineString("R_MPDL_PBLABEL_01", function()
+    return R_MPDL_BUTTONS[1]
+end, 10, "Rear Left MPD Labels", "PB 01")
+F_15E:defineString("R_MPDL_PBLABEL_02", function()
+    return R_MPDL_BUTTONS[2]
+end, 10, "Rear Left MPD Labels", "PB 02")
+F_15E:defineString("R_MPDL_PBLABEL_03", function()
+    return R_MPDL_BUTTONS[3]
+end, 10, "Rear Left MPD Labels", "PB 03")
+F_15E:defineString("R_MPDL_PBLABEL_04", function()
+    return R_MPDL_BUTTONS[4]
+end, 10, "Rear Left MPD Labels", "PB 04")
+F_15E:defineString("R_MPDL_PBLABEL_05", function()
+    return R_MPDL_BUTTONS[5]
+end, 10, "Rear Left MPD Labels", "PB 05")
+F_15E:defineString("R_MPDL_PBLABEL_06", function()
+    return R_MPDL_BUTTONS[6]
+end, 10, "Rear Left MPD Labels", "PB 06")
+F_15E:defineString("R_MPDL_PBLABEL_07", function()
+    return R_MPDL_BUTTONS[7]
+end, 10, "Rear Left MPD Labels", "PB 07")
+F_15E:defineString("R_MPDL_PBLABEL_08", function()
+    return R_MPDL_BUTTONS[8]
+end, 10, "Rear Left MPD Labels", "PB 08")
+F_15E:defineString("R_MPDL_PBLABEL_09", function()
+    return R_MPDL_BUTTONS[9]
+end, 10, "Rear Left MPD Labels", "PB 09")
+F_15E:defineString("R_MPDL_PBLABEL_10", function()
+    return R_MPDL_BUTTONS[10]
+end, 10, "Rear Left MPD Labels", "PB 10")
+F_15E:defineString("R_MPDL_PBLABEL_11", function()
+    return R_MPDL_BUTTONS[11]
+end, 10, "Rear Left MPD Labels", "PB 11")
+F_15E:defineString("R_MPDL_PBLABEL_12", function()
+    return R_MPDL_BUTTONS[12]
+end, 10, "Rear Left MPD Labels", "PB 12")
+F_15E:defineString("R_MPDL_PBLABEL_13", function()
+    return R_MPDL_BUTTONS[13]
+end, 10, "Rear Left MPD Labels", "PB 13")
+F_15E:defineString("R_MPDL_PBLABEL_14", function()
+    return R_MPDL_BUTTONS[14]
+end, 10, "Rear Left MPD Labels", "PB 14")
+F_15E:defineString("R_MPDL_PBLABEL_15", function()
+    return R_MPDL_BUTTONS[15]
+end, 10, "Rear Left MPD Labels", "PB 15")
+F_15E:defineString("R_MPDL_PBLABEL_16", function()
+    return R_MPDL_BUTTONS[16]
+end, 10, "Rear Left MPD Labels", "PB 16")
+F_15E:defineString("R_MPDL_PBLABEL_17", function()
+    return R_MPDL_BUTTONS[17]
+end, 10, "Rear Left MPD Labels", "PB 17")
+F_15E:defineString("R_MPDL_PBLABEL_18", function()
+    return R_MPDL_BUTTONS[18]
+end, 10, "Rear Left MPD Labels", "PB 18")
+F_15E:defineString("R_MPDL_PBLABEL_19", function()
+    return R_MPDL_BUTTONS[19]
+end, 10, "Rear Left MPD Labels", "PB 19")
+F_15E:defineString("R_MPDL_PBLABEL_20", function()
+    return R_MPDL_BUTTONS[20]
+end, 10, "Rear Left MPD Labels", "PB 20")
 
-F_15E:defineString("R_MPDR_PBLABEL_01", function()  
-    return R_MPDR_BUTTONS[1]  
-end, 10, "Rear Right MPD Lables", "PB 01")
-F_15E:defineString("R_MPDR_PBLABEL_02", function()  
-    return R_MPDR_BUTTONS[2]  
-end, 10, "Rear Right MPD Lables", "PB 02")
-F_15E:defineString("R_MPDR_PBLABEL_03", function()  
-    return R_MPDR_BUTTONS[3]  
-end, 10, "Rear Right MPD Lables", "PB 03")
-F_15E:defineString("R_MPDR_PBLABEL_04", function()  
-    return R_MPDR_BUTTONS[4]  
-end, 10, "Rear Right MPD Lables", "PB 04")
-F_15E:defineString("R_MPDR_PBLABEL_05", function()  
-    return R_MPDR_BUTTONS[5]  
-end, 10, "Rear Right MPD Lables", "PB 05")
-F_15E:defineString("R_MPDR_PBLABEL_06", function()  
-    return R_MPDR_BUTTONS[6]  
-end, 10, "Rear Right MPD Lables", "PB 06")
-F_15E:defineString("R_MPDR_PBLABEL_07", function()  
-    return R_MPDR_BUTTONS[7]  
-end, 10, "Rear Right MPD Lables", "PB 07")
-F_15E:defineString("R_MPDR_PBLABEL_08", function()  
-    return R_MPDR_BUTTONS[8]  
-end, 10, "Rear Right MPD Lables", "PB 08")
-F_15E:defineString("R_MPDR_PBLABEL_09", function()  
-    return R_MPDR_BUTTONS[9]  
-end, 10, "Rear Right MPD Lables", "PB 09")
-F_15E:defineString("R_MPDR_PBLABEL_10", function()  
-    return R_MPDR_BUTTONS[10]  
-end, 10, "Rear Right MPD Lables", "PB 10")
-F_15E:defineString("R_MPDR_PBLABEL_11", function()  
-    return R_MPDR_BUTTONS[11]  
-end, 10, "Rear Right MPD Lables", "PB 11")
-F_15E:defineString("R_MPDR_PBLABEL_12", function()  
-    return R_MPDR_BUTTONS[12]  
-end, 10, "Rear Right MPD Lables", "PB 12")
-F_15E:defineString("R_MPDR_PBLABEL_13", function()  
-    return R_MPDR_BUTTONS[13]  
-end, 10, "Rear Right MPD Lables", "PB 13")
-F_15E:defineString("R_MPDR_PBLABEL_14", function()  
-    return R_MPDR_BUTTONS[14]  
-end, 10, "Rear Right MPD Lables", "PB 14")
-F_15E:defineString("R_MPDR_PBLABEL_15", function()  
-    return R_MPDR_BUTTONS[15]  
-end, 10, "Rear Right MPD Lables", "PB 15")
-F_15E:defineString("R_MPDR_PBLABEL_16", function()  
-    return R_MPDR_BUTTONS[16]  
-end, 10, "Rear Right MPD Lables", "PB 16")
-F_15E:defineString("R_MPDR_PBLABEL_17", function()  
-    return R_MPDR_BUTTONS[17]  
-end, 10, "Rear Right MPD Lables", "PB 17")
-F_15E:defineString("R_MPDR_PBLABEL_18", function()  
-    return R_MPDR_BUTTONS[18]  
-end, 10, "Rear Right MPD Lables", "PB 18")
-F_15E:defineString("R_MPDR_PBLABEL_19", function()  
-    return R_MPDR_BUTTONS[19]  
-end, 10, "Rear Right MPD Lables", "PB 19")
-F_15E:defineString("R_MPDR_PBLABEL_20", function()  
-    return R_MPDR_BUTTONS[20]  
-end, 10, "Rear Right MPD Lables", "PB 20")
+F_15E:defineString("R_MPDR_PBLABEL_01", function()
+    return R_MPDR_BUTTONS[1]
+end, 10, "Rear Right MPD Labels", "PB 01")
+F_15E:defineString("R_MPDR_PBLABEL_02", function()
+    return R_MPDR_BUTTONS[2]
+end, 10, "Rear Right MPD Labels", "PB 02")
+F_15E:defineString("R_MPDR_PBLABEL_03", function()
+    return R_MPDR_BUTTONS[3]
+end, 10, "Rear Right MPD Labels", "PB 03")
+F_15E:defineString("R_MPDR_PBLABEL_04", function()
+    return R_MPDR_BUTTONS[4]
+end, 10, "Rear Right MPD Labels", "PB 04")
+F_15E:defineString("R_MPDR_PBLABEL_05", function()
+    return R_MPDR_BUTTONS[5]
+end, 10, "Rear Right MPD Labels", "PB 05")
+F_15E:defineString("R_MPDR_PBLABEL_06", function()
+    return R_MPDR_BUTTONS[6]
+end, 10, "Rear Right MPD Labels", "PB 06")
+F_15E:defineString("R_MPDR_PBLABEL_07", function()
+    return R_MPDR_BUTTONS[7]
+end, 10, "Rear Right MPD Labels", "PB 07")
+F_15E:defineString("R_MPDR_PBLABEL_08", function()
+    return R_MPDR_BUTTONS[8]
+end, 10, "Rear Right MPD Labels", "PB 08")
+F_15E:defineString("R_MPDR_PBLABEL_09", function()
+    return R_MPDR_BUTTONS[9]
+end, 10, "Rear Right MPD Labels", "PB 09")
+F_15E:defineString("R_MPDR_PBLABEL_10", function()
+    return R_MPDR_BUTTONS[10]
+end, 10, "Rear Right MPD Labels", "PB 10")
+F_15E:defineString("R_MPDR_PBLABEL_11", function()
+    return R_MPDR_BUTTONS[11]
+end, 10, "Rear Right MPD Labels", "PB 11")
+F_15E:defineString("R_MPDR_PBLABEL_12", function()
+    return R_MPDR_BUTTONS[12]
+end, 10, "Rear Right MPD Labels", "PB 12")
+F_15E:defineString("R_MPDR_PBLABEL_13", function()
+    return R_MPDR_BUTTONS[13]
+end, 10, "Rear Right MPD Labels", "PB 13")
+F_15E:defineString("R_MPDR_PBLABEL_14", function()
+    return R_MPDR_BUTTONS[14]
+end, 10, "Rear Right MPD Labels", "PB 14")
+F_15E:defineString("R_MPDR_PBLABEL_15", function()
+	return R_MPDR_BUTTONS[15]
+end, 10, "Rear Right MPD Labels", "PB 15")
+F_15E:defineString("R_MPDR_PBLABEL_16", function()
+    return R_MPDR_BUTTONS[16]
+end, 10, "Rear Right MPD Labels", "PB 16")
+F_15E:defineString("R_MPDR_PBLABEL_17", function()
+    return R_MPDR_BUTTONS[17]
+end, 10, "Rear Right MPD Labels", "PB 17")
+F_15E:defineString("R_MPDR_PBLABEL_18", function()
+    return R_MPDR_BUTTONS[18]
+end, 10, "Rear Right MPD Labels", "PB 18")
+F_15E:defineString("R_MPDR_PBLABEL_19", function()
+    return R_MPDR_BUTTONS[19]
+end, 10, "Rear Right MPD Labels", "PB 19")
+F_15E:defineString("R_MPDR_PBLABEL_20", function()
+    return R_MPDR_BUTTONS[20]
+end, 10, "Rear Right MPD Labels", "PB 20")
 
 F_15E:defineString("R_MPCDR_PBLABEL_01", function()
     return R_MPCDR_BUTTONS[1]
-end, 10, "Rear Right MPCD Lables", "PB 01")
+end, 10, "Rear Right MPCD Labels", "PB 01")
 F_15E:defineString("R_MPCDR_PBLABEL_02", function()
     return R_MPCDR_BUTTONS[2]
-end, 10, "Rear Right MPCD Lables", "PB 02")
+end, 10, "Rear Right MPCD Labels", "PB 02")
 F_15E:defineString("R_MPCDR_PBLABEL_03", function()
     return R_MPCDR_BUTTONS[3]
-end, 10, "Rear Right MPCD Lables", "PB 03")
+end, 10, "Rear Right MPCD Labels", "PB 03")
 F_15E:defineString("R_MPCDR_PBLABEL_04", function()
     return R_MPCDR_BUTTONS[4]
-end, 10, "Rear Right MPCD Lables", "PB 04")
+end, 10, "Rear Right MPCD Labels", "PB 04")
 F_15E:defineString("R_MPCDR_PBLABEL_05", function()
     return R_MPCDR_BUTTONS[5]
-end, 10, "Rear Right MPCD Lables", "PB 05")
+end, 10, "Rear Right MPCD Labels", "PB 05")
 F_15E:defineString("R_MPCDR_PBLABEL_06", function()
     return R_MPCDR_BUTTONS[6]
-end, 10, "Rear Right MPCD Lables", "PB 06")
+end, 10, "Rear Right MPCD Labels", "PB 06")
 F_15E:defineString("R_MPCDR_PBLABEL_07", function()
     return R_MPCDR_BUTTONS[7]
-end, 10, "Rear Right MPCD Lables", "PB 07")
+end, 10, "Rear Right MPCD Labels", "PB 07")
 F_15E:defineString("R_MPCDR_PBLABEL_08", function()
     return R_MPCDR_BUTTONS[8]
-end, 10, "Rear Right MPCD Lables", "PB 08")
+end, 10, "Rear Right MPCD Labels", "PB 08")
 F_15E:defineString("R_MPCDR_PBLABEL_09", function()
     return R_MPCDR_BUTTONS[9]
-end, 10, "Rear Right MPCD Lables", "PB 09")
+end, 10, "Rear Right MPCD Labels", "PB 09")
 F_15E:defineString("R_MPCDR_PBLABEL_10", function()
     return R_MPCDR_BUTTONS[10]
-end, 10, "Rear Right MPCD Lables", "PB 10")
+end, 10, "Rear Right MPCD Labels", "PB 10")
 F_15E:defineString("R_MPCDR_PBLABEL_11", function()
     return R_MPCDR_BUTTONS[11]
-end, 10, "Rear Right MPCD Lables", "PB 11")
+end, 10, "Rear Right MPCD Labels", "PB 11")
 F_15E:defineString("R_MPCDR_PBLABEL_12", function()
     return R_MPCDR_BUTTONS[12]
-end, 10, "Rear Right MPCD Lables", "PB 12")
+end, 10, "Rear Right MPCD Labels", "PB 12")
 F_15E:defineString("R_MPCDR_PBLABEL_13", function()
     return R_MPCDR_BUTTONS[13]
-end, 10, "Rear Right MPCD Lables", "PB 13")
+end, 10, "Rear Right MPCD Labels", "PB 13")
 F_15E:defineString("R_MPCDR_PBLABEL_14", function()
     return R_MPCDR_BUTTONS[14]
-end, 10, "Rear Right MPCD Lables", "PB 14")
+end, 10, "Rear Right MPCD Labels", "PB 14")
 F_15E:defineString("R_MPCDR_PBLABEL_15", function()
     return R_MPCDR_BUTTONS[15]
-end, 10, "Rear Right MPCD Lables", "PB 15")
+end, 10, "Rear Right MPCD Labels", "PB 15")
 F_15E:defineString("R_MPCDR_PBLABEL_16", function()
     return R_MPCDR_BUTTONS[16]
-end, 10, "Rear Right MPCD Lables", "PB 16")
+end, 10, "Rear Right MPCD Labels", "PB 16")
 F_15E:defineString("R_MPCDR_PBLABEL_17", function()
     return R_MPCDR_BUTTONS[17]
-end, 10, "Rear Right MPCD Lables", "PB 17")
+end, 10, "Rear Right MPCD Labels", "PB 17")
 F_15E:defineString("R_MPCDR_PBLABEL_18", function()
     return R_MPCDR_BUTTONS[18]
-end, 10, "Rear Right MPCD Lables", "PB 18")
+end, 10, "Rear Right MPCD Labels", "PB 18")
 F_15E:defineString("R_MPCDR_PBLABEL_19", function()
     return R_MPCDR_BUTTONS[19]
-end, 10, "Rear Right MPCD Lables", "PB 19")
+end, 10, "Rear Right MPCD Labels", "PB 19")
 F_15E:defineString("R_MPCDR_PBLABEL_20", function()
     return R_MPCDR_BUTTONS[20]
-end, 10, "Rear Right MPCD Lables", "PB 20")
-
+end, 10, "Rear Right MPCD Labels", "PB 20")
 
 return F_15E

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F-15E.lua
@@ -1171,11 +1171,11 @@ F_15E:defineMultipositionSwitch("R_LCP_LASER_DIG_4", 44, 3073, 73, 8, 0.1, "Rear
 F_15E:defineReadWriteRadio("UHF_RADIO", 7, 7, 3, 1000, "UHF RADIO")
 F_15E:defineReadWriteRadio("ARC_210_RADIO", 8, 7, 3, 1000, "ARC-210 RADIO")
 
-local F_MFDL_BUTTONS = {}
+local F_MPDL_BUTTONS = {}
 
-local F_MFDC_BUTTONS = {}
+local F_MPCD_BUTTONS = {}
 
-local F_MFDR_BUTTONS = {}
+local F_MPDR_BUTTONS = {}
 
 local function split(stringvalue, delimiter)
     result = {};
@@ -1273,204 +1273,488 @@ F_15E:addExportHook(function()
 	if not input then
 		return
 	end
-	F_MFDL_BUTTONS = parseMFDButtons(input)
+	F_MPDL_BUTTONS = parseMFDButtons(input)
 
 	input = list_indication(5)
 	if not input then
 		return
 	end
 	
-	F_MFDC_BUTTONS = parseMFDButtons(input)
+	F_MPCD_BUTTONS = parseMFDButtons(input)
 
 	input = list_indication(7)
 	if not input then
 		return
 	end
 	
-	F_MFDR_BUTTONS = parseMFDButtons(input)
+	F_MPDR_BUTTONS = parseMFDButtons(input)
 end)
 
-F_15E:defineString("F_MFDL_BUTTON_1", function() 
-    return F_MFDL_BUTTONS[1] 
-end, 10, "Front Left MFD", "PB 1") 
-F_15E:defineString("F_MFDL_BUTTON_2", function() 
-    return F_MFDL_BUTTONS[2] 
-end, 10, "Front Left MFD", "PB 2") 
-F_15E:defineString("F_MFDL_BUTTON_3", function() 
-    return F_MFDL_BUTTONS[3] 
-end, 10, "Front Left MFD", "PB 3") 
-F_15E:defineString("F_MFDL_BUTTON_4", function() 
-    return F_MFDL_BUTTONS[4] 
-end, 10, "Front Left MFD", "PB 4") 
-F_15E:defineString("F_MFDL_BUTTON_5", function() 
-    return F_MFDL_BUTTONS[5] 
-end, 10, "Front Left MFD", "PB 5") 
-F_15E:defineString("F_MFDL_BUTTON_6", function() 
-    return F_MFDL_BUTTONS[6] 
-end, 10, "Front Left MFD", "PB 6") 
-F_15E:defineString("F_MFDL_BUTTON_7", function() 
-    return F_MFDL_BUTTONS[7] 
-end, 10, "Front Left MFD", "PB 7") 
-F_15E:defineString("F_MFDL_BUTTON_8", function() 
-    return F_MFDL_BUTTONS[8] 
-end, 10, "Front Left MFD", "PB 8") 
-F_15E:defineString("F_MFDL_BUTTON_9", function() 
-    return F_MFDL_BUTTONS[9] 
-end, 10, "Front Left MFD", "PB 9") 
-F_15E:defineString("F_MFDL_BUTTON_10", function() 
-    return F_MFDL_BUTTONS[10] 
-end, 10, "Front Left MFD", "PB 10") 
-F_15E:defineString("F_MFDL_BUTTON_11", function() 
-    return F_MFDL_BUTTONS[11] 
-end, 10, "Front Left MFD", "PB 11") 
-F_15E:defineString("F_MFDL_BUTTON_12", function() 
-    return F_MFDL_BUTTONS[12] 
-end, 10, "Front Left MFD", "PB 12") 
-F_15E:defineString("F_MFDL_BUTTON_13", function() 
-    return F_MFDL_BUTTONS[13] 
-end, 10, "Front Left MFD", "PB 13") 
-F_15E:defineString("F_MFDL_BUTTON_14", function() 
-    return F_MFDL_BUTTONS[14] 
-end, 10, "Front Left MFD", "PB 14") 
-F_15E:defineString("F_MFDL_BUTTON_15", function() 
-    return F_MFDL_BUTTONS[15] 
-end, 10, "Front Left MFD", "PB 15") 
-F_15E:defineString("F_MFDL_BUTTON_16", function() 
-    return F_MFDL_BUTTONS[16] 
-end, 10, "Front Left MFD", "PB 16") 
-F_15E:defineString("F_MFDL_BUTTON_17", function() 
-    return F_MFDL_BUTTONS[17] 
-end, 10, "Front Left MFD", "PB 17") 
-F_15E:defineString("F_MFDL_BUTTON_18", function() 
-    return F_MFDL_BUTTONS[18] 
-end, 10, "Front Left MFD", "PB 18") 
-F_15E:defineString("F_MFDL_BUTTON_19", function() 
-    return F_MFDL_BUTTONS[19] 
-end, 10, "Front Left MFD", "PB 19") 
-F_15E:defineString("F_MFDL_BUTTON_20", function() 
-    return F_MFDL_BUTTONS[20] 
-end, 10, "Front Left MFD", "PB 20")
+F_15E:defineString("F_MPDL_PBLABEL_01", function() 
+    return F_MPDL_BUTTONS[1] 
+end, 10, "Front Left MPD Lables", "PB 01") 
+F_15E:defineString("F_MPDL_PBLABEL_02", function() 
+    return F_MPDL_BUTTONS[2] 
+end, 10, "Front Left MPD Lables", "PB 02") 
+F_15E:defineString("F_MPDL_PBLABEL_03", function() 
+    return F_MPDL_BUTTONS[3] 
+end, 10, "Front Left MPD Lables", "PB 03") 
+F_15E:defineString("F_MPDL_PBLABEL_04", function() 
+    return F_MPDL_BUTTONS[4] 
+end, 10, "Front Left MPD Lables", "PB 04") 
+F_15E:defineString("F_MPDL_PBLABEL_05", function() 
+    return F_MPDL_BUTTONS[5] 
+end, 10, "Front Left MPD Lables", "PB 05") 
+F_15E:defineString("F_MPDL_PBLABEL_06", function() 
+    return F_MPDL_BUTTONS[6] 
+end, 10, "Front Left MPD Lables", "PB 06") 
+F_15E:defineString("F_MPDL_PBLABEL_07", function() 
+    return F_MPDL_BUTTONS[7] 
+end, 10, "Front Left MPD Lables", "PB 07") 
+F_15E:defineString("F_MPDL_PBLABEL_08", function() 
+    return F_MPDL_BUTTONS[8] 
+end, 10, "Front Left MPD Lables", "PB 08") 
+F_15E:defineString("F_MPDL_PBLABEL_09", function() 
+    return F_MPDL_BUTTONS[9] 
+end, 10, "Front Left MPD Lables", "PB 09") 
+F_15E:defineString("F_MPDL_PBLABEL_10", function() 
+    return F_MPDL_BUTTONS[10] 
+end, 10, "Front Left MPD Lables", "PB 10") 
+F_15E:defineString("F_MPDL_PBLABEL_11", function() 
+    return F_MPDL_BUTTONS[11] 
+end, 10, "Front Left MPD Lables", "PB 11") 
+F_15E:defineString("F_MPDL_PBLABEL_12", function() 
+    return F_MPDL_BUTTONS[12] 
+end, 10, "Front Left MPD Lables", "PB 12") 
+F_15E:defineString("F_MPDL_PBLABEL_13", function() 
+    return F_MPDL_BUTTONS[13] 
+end, 10, "Front Left MPD Lables", "PB 13") 
+F_15E:defineString("F_MPDL_PBLABEL_14", function() 
+    return F_MPDL_BUTTONS[14] 
+end, 10, "Front Left MPD Lables", "PB 14") 
+F_15E:defineString("F_MPDL_PBLABEL_15", function() 
+    return F_MPDL_BUTTONS[15] 
+end, 10, "Front Left MPD Lables", "PB 15") 
+F_15E:defineString("F_MPDL_PBLABEL_16", function() 
+    return F_MPDL_BUTTONS[16] 
+end, 10, "Front Left MPD Lables", "PB 16") 
+F_15E:defineString("F_MPDL_PBLABEL_17", function() 
+    return F_MPDL_BUTTONS[17] 
+end, 10, "Front Left MPD Lables", "PB 17") 
+F_15E:defineString("F_MPDL_PBLABEL_18", function() 
+    return F_MPDL_BUTTONS[18] 
+end, 10, "Front Left MPD Lables", "PB 18") 
+F_15E:defineString("F_MPDL_PBLABEL_19", function() 
+    return F_MPDL_BUTTONS[19] 
+end, 10, "Front Left MPD Lables", "PB 19") 
+F_15E:defineString("F_MPDL_PBLABEL_20", function() 
+    return F_MPDL_BUTTONS[20] 
+end, 10, "Front Left MPD Lables", "PB 20")
 
-F_15E:defineString("F_MFDC_BUTTON_1", function() 
-    return F_MFDC_BUTTONS[1] 
-end, 10, "Front Center MFD", "PB 1") 
-F_15E:defineString("F_MFDC_BUTTON_2", function() 
-    return F_MFDC_BUTTONS[2] 
-end, 10, "Front Center MFD", "PB 2") 
-F_15E:defineString("F_MFDC_BUTTON_3", function() 
-    return F_MFDC_BUTTONS[3] 
-end, 10, "Front Center MFD", "PB 3") 
-F_15E:defineString("F_MFDC_BUTTON_4", function() 
-    return F_MFDC_BUTTONS[4] 
-end, 10, "Front Center MFD", "PB 4") 
-F_15E:defineString("F_MFDC_BUTTON_5", function() 
-    return F_MFDC_BUTTONS[5] 
-end, 10, "Front Center MFD", "PB 5") 
-F_15E:defineString("F_MFDC_BUTTON_6", function() 
-    return F_MFDC_BUTTONS[6] 
-end, 10, "Front Center MFD", "PB 6") 
-F_15E:defineString("F_MFDC_BUTTON_7", function() 
-    return F_MFDC_BUTTONS[7] 
-end, 10, "Front Center MFD", "PB 7") 
-F_15E:defineString("F_MFDC_BUTTON_8", function() 
-    return F_MFDC_BUTTONS[8] 
-end, 10, "Front Center MFD", "PB 8") 
-F_15E:defineString("F_MFDC_BUTTON_9", function() 
-    return F_MFDC_BUTTONS[9] 
-end, 10, "Front Center MFD", "PB 9") 
-F_15E:defineString("F_MFDC_BUTTON_10", function() 
-    return F_MFDC_BUTTONS[10] 
-end, 10, "Front Center MFD", "PB 10") 
-F_15E:defineString("F_MFDC_BUTTON_11", function() 
-    return F_MFDC_BUTTONS[11] 
-end, 10, "Front Center MFD", "PB 11") 
-F_15E:defineString("F_MFDC_BUTTON_12", function() 
-    return F_MFDC_BUTTONS[12] 
-end, 10, "Front Center MFD", "PB 12") 
-F_15E:defineString("F_MFDC_BUTTON_13", function() 
-    return F_MFDC_BUTTONS[13] 
-end, 10, "Front Center MFD", "PB 13") 
-F_15E:defineString("F_MFDC_BUTTON_14", function() 
-    return F_MFDC_BUTTONS[14] 
-end, 10, "Front Center MFD", "PB 14") 
-F_15E:defineString("F_MFDC_BUTTON_15", function() 
-    return F_MFDC_BUTTONS[15] 
-end, 10, "Front Center MFD", "PB 15") 
-F_15E:defineString("F_MFDC_BUTTON_16", function() 
-    return F_MFDC_BUTTONS[16] 
-end, 10, "Front Center MFD", "PB 16") 
-F_15E:defineString("F_MFDC_BUTTON_17", function() 
-    return F_MFDC_BUTTONS[17] 
-end, 10, "Front Center MFD", "PB 17") 
-F_15E:defineString("F_MFDC_BUTTON_18", function() 
-    return F_MFDC_BUTTONS[18] 
-end, 10, "Front Center MFD", "PB 18") 
-F_15E:defineString("F_MFDC_BUTTON_19", function() 
-    return F_MFDC_BUTTONS[19] 
-end, 10, "Front Center MFD", "PB 19") 
-F_15E:defineString("F_MFDC_BUTTON_20", function() 
-    return F_MFDC_BUTTONS[20] 
-end, 10, "Front Center MFD", "PB 20") 
+F_15E:defineString("F_MPCD_PBLABEL_01", function() 
+    return F_MPCD_BUTTONS[1] 
+end, 10, "Front Center MPCD Lables", "PB 01") 
+F_15E:defineString("F_MPCD_PBLABEL_02", function() 
+    return F_MPCD_BUTTONS[2] 
+end, 10, "Front Center MPCD Lables", "PB 02") 
+F_15E:defineString("F_MPCD_PBLABEL_03", function() 
+    return F_MPCD_BUTTONS[3] 
+end, 10, "Front Center MPCD Lables", "PB 03") 
+F_15E:defineString("F_MPCD_PBLABEL_04", function() 
+    return F_MPCD_BUTTONS[4] 
+end, 10, "Front Center MPCD Lables", "PB 04") 
+F_15E:defineString("F_MPCD_PBLABEL_05", function() 
+    return F_MPCD_BUTTONS[5] 
+end, 10, "Front Center MPCD Lables", "PB 05") 
+F_15E:defineString("F_MPCD_PBLABEL_06", function() 
+    return F_MPCD_BUTTONS[6] 
+end, 10, "Front Center MPCD Lables", "PB 06") 
+F_15E:defineString("F_MPCD_PBLABEL_07", function() 
+    return F_MPCD_BUTTONS[7] 
+end, 10, "Front Center MPCD Lables", "PB 07") 
+F_15E:defineString("F_MPCD_PBLABEL_08", function() 
+    return F_MPCD_BUTTONS[8] 
+end, 10, "Front Center MPCD Lables", "PB 08") 
+F_15E:defineString("F_MPCD_PBLABEL_09", function() 
+    return F_MPCD_BUTTONS[9] 
+end, 10, "Front Center MPCD Lables", "PB 09") 
+F_15E:defineString("F_MPCD_PBLABEL_10", function() 
+    return F_MPCD_BUTTONS[10] 
+end, 10, "Front Center MPCD Lables", "PB 10") 
+F_15E:defineString("F_MPCD_PBLABEL_11", function() 
+    return F_MPCD_BUTTONS[11] 
+end, 10, "Front Center MPCD Lables", "PB 11") 
+F_15E:defineString("F_MPCD_PBLABEL_12", function() 
+    return F_MPCD_BUTTONS[12] 
+end, 10, "Front Center MPCD Lables", "PB 12") 
+F_15E:defineString("F_MPCD_PBLABEL_13", function() 
+    return F_MPCD_BUTTONS[13] 
+end, 10, "Front Center MPCD Lables", "PB 13") 
+F_15E:defineString("F_MPCD_PBLABEL_14", function() 
+    return F_MPCD_BUTTONS[14] 
+end, 10, "Front Center MPCD Lables", "PB 14") 
+F_15E:defineString("F_MPCD_PBLABEL_15", function() 
+    return F_MPCD_BUTTONS[15] 
+end, 10, "Front Center MPCD Lables", "PB 15") 
+F_15E:defineString("F_MPCD_PBLABEL_16", function() 
+    return F_MPCD_BUTTONS[16] 
+end, 10, "Front Center MPCD Lables", "PB 16") 
+F_15E:defineString("F_MPCD_PBLABEL_17", function() 
+    return F_MPCD_BUTTONS[17] 
+end, 10, "Front Center MPCD Lables", "PB 17") 
+F_15E:defineString("F_MPCD_PBLABEL_18", function() 
+    return F_MPCD_BUTTONS[18] 
+end, 10, "Front Center MPCD Lables", "PB 18") 
+F_15E:defineString("F_MPCD_PBLABEL_19", function() 
+    return F_MPCD_BUTTONS[19] 
+end, 10, "Front Center MPCD Lables", "PB 19") 
+F_15E:defineString("F_MPCD_PBLABEL_20", function() 
+    return F_MPCD_BUTTONS[20] 
+end, 10, "Front Center MPCD Lables", "PB 20") 
 
-F_15E:defineString("F_MFDR_BUTTON_1", function() 
-    return F_MFDR_BUTTONS[1] 
-end, 10, "Front Right MFD", "PB 1") 
-F_15E:defineString("F_MFDR_BUTTON_2", function() 
-    return F_MFDR_BUTTONS[2] 
-end, 10, "Front Right MFD", "PB 2") 
-F_15E:defineString("F_MFDR_BUTTON_3", function() 
-    return F_MFDR_BUTTONS[3] 
-end, 10, "Front Right MFD", "PB 3") 
-F_15E:defineString("F_MFDR_BUTTON_4", function() 
-    return F_MFDR_BUTTONS[4] 
-end, 10, "Front Right MFD", "PB 4") 
-F_15E:defineString("F_MFDR_BUTTON_5", function() 
-    return F_MFDR_BUTTONS[5] 
-end, 10, "Front Right MFD", "PB 5") 
-F_15E:defineString("F_MFDR_BUTTON_6", function() 
-    return F_MFDR_BUTTONS[6] 
-end, 10, "Front Right MFD", "PB 6") 
-F_15E:defineString("F_MFDR_BUTTON_7", function() 
-    return F_MFDR_BUTTONS[7] 
-end, 10, "Front Right MFD", "PB 7") 
-F_15E:defineString("F_MFDR_BUTTON_8", function() 
-    return F_MFDR_BUTTONS[8] 
-end, 10, "Front Right MFD", "PB 8") 
-F_15E:defineString("F_MFDR_BUTTON_9", function() 
-    return F_MFDR_BUTTONS[9] 
-end, 10, "Front Right MFD", "PB 9") 
-F_15E:defineString("F_MFDR_BUTTON_10", function() 
-    return F_MFDR_BUTTONS[10] 
-end, 10, "Front Right MFD", "PB 10") 
-F_15E:defineString("F_MFDR_BUTTON_11", function() 
-    return F_MFDR_BUTTONS[11] 
-end, 10, "Front Right MFD", "PB 11") 
-F_15E:defineString("F_MFDR_BUTTON_12", function() 
-    return F_MFDR_BUTTONS[12] 
-end, 10, "Front Right MFD", "PB 12") 
-F_15E:defineString("F_MFDR_BUTTON_13", function() 
-    return F_MFDR_BUTTONS[13] 
-end, 10, "Front Right MFD", "PB 13") 
-F_15E:defineString("F_MFDR_BUTTON_14", function() 
-    return F_MFDR_BUTTONS[14] 
-end, 10, "Front Right MFD", "PB 14") 
-F_15E:defineString("F_MFDR_BUTTON_15", function() 
-    return F_MFDR_BUTTONS[15] 
-end, 10, "Front Right MFD", "PB 15") 
-F_15E:defineString("F_MFDR_BUTTON_16", function() 
-    return F_MFDR_BUTTONS[16] 
-end, 10, "Front Right MFD", "PB 16") 
-F_15E:defineString("F_MFDR_BUTTON_17", function() 
-    return F_MFDR_BUTTONS[17] 
-end, 10, "Front Right MFD", "PB 17") 
-F_15E:defineString("F_MFDR_BUTTON_18", function() 
-    return F_MFDR_BUTTONS[18] 
-end, 10, "Front Right MFD", "PB 18") 
-F_15E:defineString("F_MFDR_BUTTON_19", function() 
-    return F_MFDR_BUTTONS[19] 
-end, 10, "Front Right MFD", "PB 19") 
-F_15E:defineString("F_MFDR_BUTTON_20", function() 
-    return F_MFDR_BUTTONS[20] 
-end, 10, "Front Right MFD", "PB 20")
+F_15E:defineString("F_MPDR_PBLABEL_01", function() 
+    return F_MPDR_BUTTONS[1] 
+end, 10, "Front Right MPD Lables", "PB 01") 
+F_15E:defineString("F_MPDR_PBLABEL_02", function() 
+    return F_MPDR_BUTTONS[2] 
+end, 10, "Front Right MPD Lables", "PB 02") 
+F_15E:defineString("F_MPDR_PBLABEL_03", function() 
+    return F_MPDR_BUTTONS[3] 
+end, 10, "Front Right MPD Lables", "PB 03") 
+F_15E:defineString("F_MPDR_PBLABEL_04", function() 
+    return F_MPDR_BUTTONS[4] 
+end, 10, "Front Right MPD Lables", "PB 04") 
+F_15E:defineString("F_MPDR_PBLABEL_05", function() 
+    return F_MPDR_BUTTONS[5] 
+end, 10, "Front Right MPD Lables", "PB 05") 
+F_15E:defineString("F_MPDR_PBLABEL_06", function() 
+    return F_MPDR_BUTTONS[6] 
+end, 10, "Front Right MPD Lables", "PB 06") 
+F_15E:defineString("F_MPDR_PBLABEL_07", function() 
+    return F_MPDR_BUTTONS[7] 
+end, 10, "Front Right MPD Lables", "PB 07") 
+F_15E:defineString("F_MPDR_PBLABEL_08", function() 
+    return F_MPDR_BUTTONS[8] 
+end, 10, "Front Right MPD Lables", "PB 08") 
+F_15E:defineString("F_MPDR_PBLABEL_09", function() 
+    return F_MPDR_BUTTONS[9] 
+end, 10, "Front Right MPD Lables", "PB 09") 
+F_15E:defineString("F_MPDR_PBLABEL_10", function() 
+    return F_MPDR_BUTTONS[10] 
+end, 10, "Front Right MPD Lables", "PB 10") 
+F_15E:defineString("F_MPDR_PBLABEL_11", function() 
+    return F_MPDR_BUTTONS[11] 
+end, 10, "Front Right MPD Lables", "PB 11") 
+F_15E:defineString("F_MPDR_PBLABEL_12", function() 
+    return F_MPDR_BUTTONS[12] 
+end, 10, "Front Right MPD Lables", "PB 12") 
+F_15E:defineString("F_MPDR_PBLABEL_13", function() 
+    return F_MPDR_BUTTONS[13] 
+end, 10, "Front Right MPD Lables", "PB 13") 
+F_15E:defineString("F_MPDR_PBLABEL_14", function() 
+    return F_MPDR_BUTTONS[14] 
+end, 10, "Front Right MPD Lables", "PB 14") 
+F_15E:defineString("F_MPDR_PBLABEL_15", function() 
+    return F_MPDR_BUTTONS[15] 
+end, 10, "Front Right MPD Lables", "PB 15") 
+F_15E:defineString("F_MPDR_PBLABEL_16", function() 
+    return F_MPDR_BUTTONS[16] 
+end, 10, "Front Right MPD Lables", "PB 16") 
+F_15E:defineString("F_MPDR_PBLABEL_17", function() 
+    return F_MPDR_BUTTONS[17] 
+end, 10, "Front Right MPD Lables", "PB 17") 
+F_15E:defineString("F_MPDR_PBLABEL_18", function() 
+    return F_MPDR_BUTTONS[18] 
+end, 10, "Front Right MPD Lables", "PB 18") 
+F_15E:defineString("F_MPDR_PBLABEL_19", function() 
+    return F_MPDR_BUTTONS[19] 
+end, 10, "Front Right MPD Lables", "PB 19") 
+F_15E:defineString("F_MPDR_PBLABEL_20", function() 
+    return F_MPDR_BUTTONS[20] 
+end, 10, "Front Right MPD Lables", "PB 20")
+
+
+local R_MPCDL_BUTTONS = {}
+
+local R_MPDL_BUTTONS = {}
+
+local R_MPDR_BUTTONS = {}
+
+local R_MPCDR_BUTTONS = {}
+
+
+F_15E:addExportHook(function()
+	local input = list_indication(10)
+	if not input then
+		return
+	end
+	R_MPCDL_BUTTONS = parseMFDButtons(input)
+
+	input = list_indication(12)
+	if not input then
+		return
+	end
+	
+	R_MPDL_BUTTONS = parseMFDButtons(input)
+
+	input = list_indication(14)
+	if not input then
+		return
+	end
+	
+	R_MPDR_BUTTONS = parseMFDButtons(input)
+
+	input = list_indication(16)
+	if not input then
+		return
+	end
+	
+	R_MPCDR_BUTTONS = parseMFDButtons(input)
+end)
+
+F_15E:defineString("R_MPCDL_PBLABEL_01", function()  
+    return R_MPCDL_BUTTONS[1]  
+end, 10, "Rear Left MPCD Lables", "PB 01")
+F_15E:defineString("R_MPCDL_PBLABEL_02", function()  
+    return R_MPCDL_BUTTONS[2]  
+end, 10, "Rear Left MPCD Lables", "PB 02")
+F_15E:defineString("R_MPCDL_PBLABEL_03", function()  
+    return R_MPCDL_BUTTONS[3]  
+end, 10, "Rear Left MPCD Lables", "PB 03")
+F_15E:defineString("R_MPCDL_PBLABEL_04", function()  
+    return R_MPCDL_BUTTONS[4]  
+end, 10, "Rear Left MPCD Lables", "PB 04")
+F_15E:defineString("R_MPCDL_PBLABEL_05", function()  
+    return R_MPCDL_BUTTONS[5]  
+end, 10, "Rear Left MPCD Lables", "PB 05")
+F_15E:defineString("R_MPCDL_PBLABEL_06", function()  
+    return R_MPCDL_BUTTONS[6]  
+end, 10, "Rear Left MPCD Lables", "PB 06")
+F_15E:defineString("R_MPCDL_PBLABEL_07", function()  
+    return R_MPCDL_BUTTONS[7]  
+end, 10, "Rear Left MPCD Lables", "PB 07")
+F_15E:defineString("R_MPCDL_PBLABEL_08", function()  
+    return R_MPCDL_BUTTONS[8]  
+end, 10, "Rear Left MPCD Lables", "PB 08")
+F_15E:defineString("R_MPCDL_PBLABEL_09", function()  
+    return R_MPCDL_BUTTONS[9]  
+end, 10, "Rear Left MPCD Lables", "PB 9")
+F_15E:defineString("R_MPCDL_PBLABEL_10", function()  
+    return R_MPCDL_BUTTONS[10]  
+end, 10, "Rear Left MPCD Lables", "PB 10")
+F_15E:defineString("R_MPCDL_PBLABEL_11", function()  
+    return R_MPCDL_BUTTONS[11]  
+end, 10, "Rear Left MPCD Lables", "PB 11")
+F_15E:defineString("R_MPCDL_PBLABEL_12", function()  
+    return R_MPCDL_BUTTONS[12]  
+end, 10, "Rear Left MPCD Lables", "PB 12")
+F_15E:defineString("R_MPCDL_PBLABEL_13", function()  
+    return R_MPCDL_BUTTONS[13]  
+end, 10, "Rear Left MPCD Lables", "PB 13")
+F_15E:defineString("R_MPCDL_PBLABEL_14", function()  
+    return R_MPCDL_BUTTONS[14]  
+end, 10, "Rear Left MPCD Lables", "PB 14")
+F_15E:defineString("R_MPCDL_PBLABEL_15", function()  
+    return R_MPCDL_BUTTONS[15]  
+end, 10, "Rear Left MPCD Lables", "PB 15")
+F_15E:defineString("R_MPCDL_PBLABEL_16", function()  
+    return R_MPCDL_BUTTONS[16]  
+end, 10, "Rear Left MPCD Lables", "PB 16")
+F_15E:defineString("R_MPCDL_PBLABEL_17", function()  
+    return R_MPCDL_BUTTONS[17]  
+end, 10, "Rear Left MPCD Lables", "PB 17")
+F_15E:defineString("R_MPCDL_PBLABEL_18", function()  
+    return R_MPCDL_BUTTONS[18]  
+end, 10, "Rear Left MPCD Lables", "PB 18")
+F_15E:defineString("R_MPCDL_PBLABEL_19", function()  
+    return R_MPCDL_BUTTONS[19]  
+end, 10, "Rear Left MPCD Lables", "PB 19")
+F_15E:defineString("R_MPCDL_PBLABEL_20", function()  
+    return R_MPCDL_BUTTONS[20]  
+end, 10, "Rear Left MPCD Lables", "PB 20")
+
+F_15E:defineString("R_MPDL_PBLABEL_01", function()  
+    return R_MPDL_BUTTONS[1]  
+end, 10, "Rear Left MPD Lables", "PB 01")
+F_15E:defineString("R_MPDL_PBLABEL_02", function()  
+    return R_MPDL_BUTTONS[2]  
+end, 10, "Rear Left MPD Lables", "PB 02")
+F_15E:defineString("R_MPDL_PBLABEL_03", function()  
+    return R_MPDL_BUTTONS[3]  
+end, 10, "Rear Left MPD Lables", "PB 03")
+F_15E:defineString("R_MPDL_PBLABEL_04", function()  
+    return R_MPDL_BUTTONS[4]  
+end, 10, "Rear Left MPD Lables", "PB 04")
+F_15E:defineString("R_MPDL_PBLABEL_05", function()  
+    return R_MPDL_BUTTONS[5]  
+end, 10, "Rear Left MPD Lables", "PB 05")
+F_15E:defineString("R_MPDL_PBLABEL_06", function()  
+    return R_MPDL_BUTTONS[6]  
+end, 10, "Rear Left MPD Lables", "PB 06")
+F_15E:defineString("R_MPDL_PBLABEL_07", function()  
+    return R_MPDL_BUTTONS[7]  
+end, 10, "Rear Left MPD Lables", "PB 07")
+F_15E:defineString("R_MPDL_PBLABEL_08", function()  
+    return R_MPDL_BUTTONS[8]  
+end, 10, "Rear Left MPD Lables", "PB 08")
+F_15E:defineString("R_MPDL_PBLABEL_09", function()  
+    return R_MPDL_BUTTONS[9]  
+end, 10, "Rear Left MPD Lables", "PB 09")
+F_15E:defineString("R_MPDL_PBLABEL_10", function()  
+    return R_MPDL_BUTTONS[10]  
+end, 10, "Rear Left MPD Lables", "PB 10")
+F_15E:defineString("R_MPDL_PBLABEL_11", function()  
+    return R_MPDL_BUTTONS[11]  
+end, 10, "Rear Left MPD Lables", "PB 11")
+F_15E:defineString("R_MPDL_PBLABEL_12", function()  
+    return R_MPDL_BUTTONS[12]  
+end, 10, "Rear Left MPD Lables", "PB 12")
+F_15E:defineString("R_MPDL_PBLABEL_13", function()  
+    return R_MPDL_BUTTONS[13]  
+end, 10, "Rear Left MPD Lables", "PB 13")
+F_15E:defineString("R_MPDL_PBLABEL_14", function()  
+    return R_MPDL_BUTTONS[14]  
+end, 10, "Rear Left MPD Lables", "PB 14")
+F_15E:defineString("R_MPDL_PBLABEL_15", function()  
+    return R_MPDL_BUTTONS[15]  
+end, 10, "Rear Left MPD Lables", "PB 15")
+F_15E:defineString("R_MPDL_PBLABEL_16", function()  
+    return R_MPDL_BUTTONS[16]  
+end, 10, "Rear Left MPD Lables", "PB 16")
+F_15E:defineString("R_MPDL_PBLABEL_17", function()  
+    return R_MPDL_BUTTONS[17]  
+end, 10, "Rear Left MPD Lables", "PB 17")
+F_15E:defineString("R_MPDL_PBLABEL_18", function()  
+    return R_MPDL_BUTTONS[18]  
+end, 10, "Rear Left MPD Lables", "PB 18")
+F_15E:defineString("R_MPDL_PBLABEL_19", function()  
+    return R_MPDL_BUTTONS[19]  
+end, 10, "Rear Left MPD Lables", "PB 19")
+F_15E:defineString("R_MPDL_PBLABEL_20", function()  
+    return R_MPDL_BUTTONS[20]  
+end, 10, "Rear Left MPD Lables", "PB 20")
+
+F_15E:defineString("R_MPDR_PBLABEL_01", function()  
+    return R_MPDR_BUTTONS[1]  
+end, 10, "Rear Right MPD Lables", "PB 01")
+F_15E:defineString("R_MPDR_PBLABEL_02", function()  
+    return R_MPDR_BUTTONS[2]  
+end, 10, "Rear Right MPD Lables", "PB 02")
+F_15E:defineString("R_MPDR_PBLABEL_03", function()  
+    return R_MPDR_BUTTONS[3]  
+end, 10, "Rear Right MPD Lables", "PB 03")
+F_15E:defineString("R_MPDR_PBLABEL_04", function()  
+    return R_MPDR_BUTTONS[4]  
+end, 10, "Rear Right MPD Lables", "PB 04")
+F_15E:defineString("R_MPDR_PBLABEL_05", function()  
+    return R_MPDR_BUTTONS[5]  
+end, 10, "Rear Right MPD Lables", "PB 05")
+F_15E:defineString("R_MPDR_PBLABEL_06", function()  
+    return R_MPDR_BUTTONS[6]  
+end, 10, "Rear Right MPD Lables", "PB 06")
+F_15E:defineString("R_MPDR_PBLABEL_07", function()  
+    return R_MPDR_BUTTONS[7]  
+end, 10, "Rear Right MPD Lables", "PB 07")
+F_15E:defineString("R_MPDR_PBLABEL_08", function()  
+    return R_MPDR_BUTTONS[8]  
+end, 10, "Rear Right MPD Lables", "PB 08")
+F_15E:defineString("R_MPDR_PBLABEL_09", function()  
+    return R_MPDR_BUTTONS[9]  
+end, 10, "Rear Right MPD Lables", "PB 09")
+F_15E:defineString("R_MPDR_PBLABEL_10", function()  
+    return R_MPDR_BUTTONS[10]  
+end, 10, "Rear Right MPD Lables", "PB 10")
+F_15E:defineString("R_MPDR_PBLABEL_11", function()  
+    return R_MPDR_BUTTONS[11]  
+end, 10, "Rear Right MPD Lables", "PB 11")
+F_15E:defineString("R_MPDR_PBLABEL_12", function()  
+    return R_MPDR_BUTTONS[12]  
+end, 10, "Rear Right MPD Lables", "PB 12")
+F_15E:defineString("R_MPDR_PBLABEL_13", function()  
+    return R_MPDR_BUTTONS[13]  
+end, 10, "Rear Right MPD Lables", "PB 13")
+F_15E:defineString("R_MPDR_PBLABEL_14", function()  
+    return R_MPDR_BUTTONS[14]  
+end, 10, "Rear Right MPD Lables", "PB 14")
+F_15E:defineString("R_MPDR_PBLABEL_15", function()  
+    return R_MPDR_BUTTONS[15]  
+end, 10, "Rear Right MPD Lables", "PB 15")
+F_15E:defineString("R_MPDR_PBLABEL_16", function()  
+    return R_MPDR_BUTTONS[16]  
+end, 10, "Rear Right MPD Lables", "PB 16")
+F_15E:defineString("R_MPDR_PBLABEL_17", function()  
+    return R_MPDR_BUTTONS[17]  
+end, 10, "Rear Right MPD Lables", "PB 17")
+F_15E:defineString("R_MPDR_PBLABEL_18", function()  
+    return R_MPDR_BUTTONS[18]  
+end, 10, "Rear Right MPD Lables", "PB 18")
+F_15E:defineString("R_MPDR_PBLABEL_19", function()  
+    return R_MPDR_BUTTONS[19]  
+end, 10, "Rear Right MPD Lables", "PB 19")
+F_15E:defineString("R_MPDR_PBLABEL_20", function()  
+    return R_MPDR_BUTTONS[20]  
+end, 10, "Rear Right MPD Lables", "PB 20")
+
+F_15E:defineString("R_MPCDR_PBLABEL_01", function()
+    return R_MPCDR_BUTTONS[1]
+end, 10, "Rear Right MPCD Lables", "PB 01")
+F_15E:defineString("R_MPCDR_PBLABEL_02", function()
+    return R_MPCDR_BUTTONS[2]
+end, 10, "Rear Right MPCD Lables", "PB 02")
+F_15E:defineString("R_MPCDR_PBLABEL_03", function()
+    return R_MPCDR_BUTTONS[3]
+end, 10, "Rear Right MPCD Lables", "PB 03")
+F_15E:defineString("R_MPCDR_PBLABEL_04", function()
+    return R_MPCDR_BUTTONS[4]
+end, 10, "Rear Right MPCD Lables", "PB 04")
+F_15E:defineString("R_MPCDR_PBLABEL_05", function()
+    return R_MPCDR_BUTTONS[5]
+end, 10, "Rear Right MPCD Lables", "PB 05")
+F_15E:defineString("R_MPCDR_PBLABEL_06", function()
+    return R_MPCDR_BUTTONS[6]
+end, 10, "Rear Right MPCD Lables", "PB 06")
+F_15E:defineString("R_MPCDR_PBLABEL_07", function()
+    return R_MPCDR_BUTTONS[7]
+end, 10, "Rear Right MPCD Lables", "PB 07")
+F_15E:defineString("R_MPCDR_PBLABEL_08", function()
+    return R_MPCDR_BUTTONS[8]
+end, 10, "Rear Right MPCD Lables", "PB 08")
+F_15E:defineString("R_MPCDR_PBLABEL_09", function()
+    return R_MPCDR_BUTTONS[9]
+end, 10, "Rear Right MPCD Lables", "PB 09")
+F_15E:defineString("R_MPCDR_PBLABEL_10", function()
+    return R_MPCDR_BUTTONS[10]
+end, 10, "Rear Right MPCD Lables", "PB 10")
+F_15E:defineString("R_MPCDR_PBLABEL_11", function()
+    return R_MPCDR_BUTTONS[11]
+end, 10, "Rear Right MPCD Lables", "PB 11")
+F_15E:defineString("R_MPCDR_PBLABEL_12", function()
+    return R_MPCDR_BUTTONS[12]
+end, 10, "Rear Right MPCD Lables", "PB 12")
+F_15E:defineString("R_MPCDR_PBLABEL_13", function()
+    return R_MPCDR_BUTTONS[13]
+end, 10, "Rear Right MPCD Lables", "PB 13")
+F_15E:defineString("R_MPCDR_PBLABEL_14", function()
+    return R_MPCDR_BUTTONS[14]
+end, 10, "Rear Right MPCD Lables", "PB 14")
+F_15E:defineString("R_MPCDR_PBLABEL_15", function()
+    return R_MPCDR_BUTTONS[15]
+end, 10, "Rear Right MPCD Lables", "PB 15")
+F_15E:defineString("R_MPCDR_PBLABEL_16", function()
+    return R_MPCDR_BUTTONS[16]
+end, 10, "Rear Right MPCD Lables", "PB 16")
+F_15E:defineString("R_MPCDR_PBLABEL_17", function()
+    return R_MPCDR_BUTTONS[17]
+end, 10, "Rear Right MPCD Lables", "PB 17")
+F_15E:defineString("R_MPCDR_PBLABEL_18", function()
+    return R_MPCDR_BUTTONS[18]
+end, 10, "Rear Right MPCD Lables", "PB 18")
+F_15E:defineString("R_MPCDR_PBLABEL_19", function()
+    return R_MPCDR_BUTTONS[19]
+end, 10, "Rear Right MPCD Lables", "PB 19")
+F_15E:defineString("R_MPCDR_PBLABEL_20", function()
+    return R_MPCDR_BUTTONS[20]
+end, 10, "Rear Right MPCD Lables", "PB 20")
+
 
 return F_15E


### PR DESCRIPTION
Allows arduinos, etc to get the text associated with the buttons on the front MFDs(or MPCD whatever the name is)
Rear displays not supported yet