### PR TITLE
FA-18C: Rename Fire Warning/Extinguisher Light

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -243,8 +243,8 @@ FA_18C_hornet:defineIndicatorLight("RH_ADV_SPARE_RH4", 36, "RH Advisory Panel", 
 FA_18C_hornet:defineIndicatorLight("RH_ADV_SPARE_RH5", 37, "RH Advisory Panel", "SPARE RH5 (green)")
 
 -- 9. APU Fire Warning / Extinguisher Light
-FA_18C_hornet:defineIndicatorLight("FIRE_APU_LT", 29, "APU Fire Warning Extinguisher Light", "FIRE APU (red)")
-FA_18C_hornet:definePushButton("APU_FIRE_BTN", 12, 3009, 30, "APU Fire Warning Extinguisher Light", "APU Fire Warning/Extinguisher Light")
+FA_18C_hornet:defineIndicatorLight("FIRE_APU_LT", 29, "APU Fire Warning Extinguisher Light", "FIRE APU (red) Light")
+FA_18C_hornet:definePushButton("APU_FIRE_BTN", 12, 3009, 30, "APU Fire Warning Extinguisher Light", "APU Fire Warning/Extinguisher Button")
 
 -- 10. Right Engine Fire Warning / Extinguisher Light
 FA_18C_hornet:defineIndicatorLight("FIRE_RIGHT_LT", 26, "Right Engine Fire Warning Extinguisher Light", "FIRE RIGHT (red)")

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/FA-18C_hornet.lua
@@ -243,7 +243,7 @@ FA_18C_hornet:defineIndicatorLight("RH_ADV_SPARE_RH4", 36, "RH Advisory Panel", 
 FA_18C_hornet:defineIndicatorLight("RH_ADV_SPARE_RH5", 37, "RH Advisory Panel", "SPARE RH5 (green)")
 
 -- 9. APU Fire Warning / Extinguisher Light
-FA_18C_hornet:defineIndicatorLight("FIRE_APU_LT", 29, "APU Fire Warning Extinguisher Light", "FIRE APU (red) Light")
+FA_18C_hornet:defineIndicatorLight("FIRE_APU_LT", 29, "APU Fire Warning Extinguisher Light", "FIRE APU Light (red)")
 FA_18C_hornet:definePushButton("APU_FIRE_BTN", 12, 3009, 30, "APU Fire Warning Extinguisher Light", "APU Fire Warning/Extinguisher Button")
 
 -- 10. Right Engine Fire Warning / Extinguisher Light


### PR DESCRIPTION
As reported in #1058.

Changes Fire Warning/Extinguisher button and light to more descriptive and logical descriptions.