### PR TITLE
Fix log spam when ejecting

### DIFF
--- a/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
+++ b/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
@@ -66,7 +66,10 @@ end
 --- @param module Module
 --- @param dev0 CockpitDevice?
 function BIOSStateMachine:queue_module_data(module, dev0)
-	dev0 = module.dev0_required and dev0 or {} -- if dev0 isn't required, just pass an empty object
+	if not module.dev0_required and dev0 == nil then
+		dev0 = {} -- if dev0 isn't required and is nil, just pass an empty object
+	end
+
 	if dev0 ~= nil then
 		for _, hook in ipairs(module.exportHooks) do
 			local status, result = pcall(hook, dev0)


### PR DESCRIPTION
Fixes the issue where the DCS-BIOS.log file get's thousands of lines of errors and the file grows by MBs every seconds when ejecting from an aircraft.