### PR TITLE
Update lua workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up lua
-        uses: leafo/gh-actions-lua@v10
+        # uses: leafo/gh-actions-lua@v10 # needs cache dependency update https://github.com/leafo/gh-actions-lua/pull/56
+        uses: lewis6991/gh-actions-lua@01aab24c4de9555717b685f9b142a2abbe12ef14
         with:
           luaVersion: "5.1.5"
 


### PR DESCRIPTION
Existing lua workflow uses an older version of the caching dependency which results in absurdly long execution times. The PR to fix this has been sitting dormant for a bit now, so in the mean time we'll just use the PR branch