### PR TITLE
Update log handler for duplicate messages

### DIFF
--- a/Scripts/DCS-BIOS/BIOSConfig.lua
+++ b/Scripts/DCS-BIOS/BIOSConfig.lua
@@ -31,7 +31,7 @@ local BIOSConfig = {
 		},
 	},
 	dev_mode = true,
-	clean_logs = false,
+	clean_logs = true,
 }
 
 return BIOSConfig

--- a/Scripts/DCS-BIOS/BIOSConfig.lua
+++ b/Scripts/DCS-BIOS/BIOSConfig.lua
@@ -14,6 +14,7 @@ module("BIOSConfig", package.seeall)
 --- @field tcp_config TCPConnectionConfig[]
 --- @field udp_config UDPConnectionConfig[]
 --- @field dev_mode boolean whether dev mode is enabled and json/header files should be written
+--- @field clean_logs boolean whether duplicate log messages should be removed
 local BIOSConfig = {
 	tcp_config = {
 		{
@@ -30,6 +31,7 @@ local BIOSConfig = {
 		},
 	},
 	dev_mode = true,
+	clean_logs = false,
 }
 
 return BIOSConfig

--- a/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
+++ b/Scripts/DCS-BIOS/lib/BIOSStateMachine.lua
@@ -177,6 +177,7 @@ function BIOSStateMachine:step()
 end
 
 function BIOSStateMachine:shutdown()
+	Log:flush_memory_error()
 	Log:log_info("shutting down dcs-bios")
 	local dev0 = GetDevice(0)
 

--- a/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
@@ -54,14 +54,13 @@ function MemoryAllocation:setValue(value)
 	local clean_value = value < 0 and value + 0.01 >= 0 and 0 or value
 
 	clean_value = math.floor(clean_value)
-	if clean_value < 0 then
-		Log:log_error(string.format("MemoryAllocation.lua: value %f (originally %f) is too small for %s (address %d mask %d)", clean_value, value, self.debug_name or "n/a", self.address, self.mask))
+	if clean_value < 0 or clean_value > self.maxValue then
+		Log:log_memory_error(self.debug_name or "n/a", value, self.maxValue, clean_value, self.address, self.mask)
 		return
+	else
+		Log:reset_control_memory_errors(self.debug_name or "n/a")
 	end
-	if clean_value > self.maxValue then
-		Log:log_error(string.format("MemoryAllocation.lua: value %f (originally %f) is larger than max %d for %s (address %d mask %d)", clean_value, value, self.maxValue, self.debug_name or "n/a", self.address, self.mask))
-		return
-	end
+
 	assert(clean_value >= 0)
 	assert(clean_value <= self.maxValue)
 	if self.value ~= clean_value then


### PR DESCRIPTION
This PR fixes #910 and reduces spam for out of range controls like mentioned in #1215.

- When a log message is the exact same as the previous log message and within a set number of seconds, it is not send and stored until a new different message arrives (or dcs-bios is shutdown), and then sends a recap of the number of skiped messages in the form : `2025-08-28 00:00:42  LOG_LEVEL X duplicate message(s) skipped.`

- When a control is out of range, a first message is sent like before but then all subsequent out of range error logs for this control are cached and not sent until the control is back within range (or dcs-bios is shutdown), and then sends a recap of the number of skiped messages and more detailed infoa bout the out of range issue in the form: `2025-08-28 00:00:42  ERROR  MemoryAllocation.lua: Skipped X value errors for CONTROL_NAME - Min recorded value: X, Max recorded value: X`

This behavior can be toggled off to write every single log messages like before by setting the new `clean_logs` setting to false