### PR TITLE
CH-47F: Fix CDU FPLN Data ETE field right bracket position

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/displays/CH_47F_CDU.lua
+++ b/Scripts/DCS-BIOS/lib/modules/displays/CH_47F_CDU.lua
@@ -12040,7 +12040,7 @@ local CH_47F_CDU = {
 				"CDU_SUBSET_FPLN_DATA_1",
 			},
 			id = "ETE_right_bracket",
-			x = 14,
+			x = 24,
 			y = 9,
 			color = "w",
 		},


### PR DESCRIPTION
Discovered while investigating https://github.com/DCS-Skunkworks/dcs-bios/issues/1246