### PR TITLE
F4U-1D: Add Water Pressure Gauge

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F4U-1D.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/F4U-1D.lua
@@ -273,8 +273,10 @@ F4U_1D:definePushButton("VOLTAMMETER_VOLTS_AMPS_BUTTON", devices.ELECTRO, 3001, 
 -- Accelerometer
 -- local ACCELEROMETER = "Accelerometer"
 
--- Fuel Pressure Gauge
--- local FUEL_PRESSURE_GAUGE = "Fuel Pressure Gauge"
+-- Water Pressure Gauge
+local WATER_PRESSURE_GAUGE = "Water Pressure Gauge"
+
+F4U_1D:defineFloat("WATER_PRESSURE_GAUGE", 242, { 0, 1 }, WATER_PRESSURE_GAUGE, "Water Pressure Gauge")
 
 -- Emergency Pressure Release
 local EMERGENCY_PRESSURE_RELEASE = "Emergency Pressure Release"


### PR DESCRIPTION
Fixes #1181

Renamed to Water Pressure instead of Fuel Pressure, it appears that an extra "Fuel Pressure" gauge was used on the F4U-1D for Water Pressure.