### PR TITLE
C-130J: Flap and Trim Indicator Panel

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
@@ -697,11 +697,11 @@ C_130J:define3PosTumb("LANDING_LIGHTS_MOTOR_R", devices.LIGHTING_PANELS, 3003, 3
 -- Flap and Trim Indicator Panel
 local FLAP_TRIM_INDICATOR = "Flap and Trim Indicator Panel"
 
-C_130J:defineFloat("FLAP_TRIM_INDICATOR_LEFT_AILERON", 470, { -1, 1 }, FLAP_TRIM_INDICATOR, "Left Aileron Trim Indicator")
-C_130J:defineFloat("FLAP_TRIM_INDICATOR_RIGHT_AILERON", 471, { -1, 1 }, FLAP_TRIM_INDICATOR, "Right Aileron Trim Indicator")
-C_130J:defineFloat("FLAP_TRIM_INDICATOR_RUDDER", 472, { -1, 1 }, FLAP_TRIM_INDICATOR, "Rudder Trim Indicator")
-C_130J:defineFloat("FLAP_TRIM_INDICATOR_ELEVATOR", 473, { -1, 1 }, FLAP_TRIM_INDICATOR, "Elevator Trim Indicator")
-C_130J:defineFloat("FLAP_TRIM_INDICATOR_FLAPS", 426, { -1, 1 }, FLAP_TRIM_INDICATOR, "Flaps Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_LEFT_AILERON", 470, { 0, 1 }, FLAP_TRIM_INDICATOR, "Left Aileron Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_RIGHT_AILERON", 471, { 0, 1 }, FLAP_TRIM_INDICATOR, "Right Aileron Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_RUDDER", 472, { 0, 1 }, FLAP_TRIM_INDICATOR, "Rudder Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_ELEVATOR", 473, { 0, 1 }, FLAP_TRIM_INDICATOR, "Elevator Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_FLAPS", 426, { 0, 1 }, FLAP_TRIM_INDICATOR, "Flaps Trim Indicator")
 
 -- Standby Altimeter/Airspeed Indicator
 

--- a/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
+++ b/Scripts/DCS-BIOS/lib/modules/aircraft_modules/C-130J.lua
@@ -695,6 +695,13 @@ C_130J:define3PosTumb("LANDING_LIGHTS_MOTOR_L", devices.LIGHTING_PANELS, 3004, 3
 C_130J:define3PosTumb("LANDING_LIGHTS_MOTOR_R", devices.LIGHTING_PANELS, 3003, 31, LANDING, "Right Landing Light Motor", { positions = { "RETRACT", "HOLD", "EXTEND" } })
 
 -- Flap and Trim Indicator Panel
+local FLAP_TRIM_INDICATOR = "Flap and Trim Indicator Panel"
+
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_LEFT_AILERON", 470, { -1, 1 }, FLAP_TRIM_INDICATOR, "Left Aileron Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_RIGHT_AILERON", 471, { -1, 1 }, FLAP_TRIM_INDICATOR, "Right Aileron Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_RUDDER", 472, { -1, 1 }, FLAP_TRIM_INDICATOR, "Rudder Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_ELEVATOR", 473, { -1, 1 }, FLAP_TRIM_INDICATOR, "Elevator Trim Indicator")
+C_130J:defineFloat("FLAP_TRIM_INDICATOR_FLAPS", 426, { -1, 1 }, FLAP_TRIM_INDICATOR, "Flaps Trim Indicator")
 
 -- Standby Altimeter/Airspeed Indicator
 


### PR DESCRIPTION
All the trim indicators technically go from -1 to 1 in Model Viewer (where the needle goes outside the range drawn on the model) but -1 to 0 is out of range and the full scale is between 0 and 1.
I've tried in game and I can't seem to make the needle go outside the 0 to 1 range.

@charliefoxtwo Should we keep the range -1 to 1 to cover the full technically possible range (current implementation) or go for the 0 to 1 so that it make more sense compared to the scale?

Fixes #1437