### PR TITLE
Core: Clamp values within 1% of bounds

### DIFF
--- a/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
+++ b/Scripts/DCS-BIOS/lib/modules/memory_map/MemoryAllocation.lua
@@ -50,8 +50,8 @@ function MemoryAllocation:setValue(value)
 	assert(self.maxValue)
 	assert(value)
 
-	-- check if value is close enough to our min that it could be a rounding error
-	local clean_value = value < 0 and value + 0.01 >= 0 and 0 or value
+	-- check if value is close enough to our min/max that it could be a rounding error
+	local clean_value = self:clean_value(value)
 
 	clean_value = math.floor(clean_value)
 	if clean_value < 0 or clean_value > self.maxValue then
@@ -67,6 +67,18 @@ function MemoryAllocation:setValue(value)
 		self.value = clean_value
 		self.memoryMapEntry.dirty = true
 	end
+end
+
+function MemoryAllocation:clean_value(value)
+	local THRESHOLD = 0.01 -- within 1% is fine
+
+	if value < 0 then
+		return math.abs(value) / self.maxValue < THRESHOLD and 0 or value
+	elseif value > self.maxValue then
+		return (value - self.maxValue) / self.maxValue < THRESHOLD and self.maxValue or value
+	end
+
+	return value
 end
 
 return MemoryAllocation

--- a/Scripts/DCS-BIOS/test/MemoryMapEntryTest.lua
+++ b/Scripts/DCS-BIOS/test/MemoryMapEntryTest.lua
@@ -83,7 +83,7 @@ function TestMemoryMapEntry:testMemoryAllocation()
 	lu.assertEquals(entry:getValue(), 0)
 	lu.assertIsFalse(entry.dirty)
 
-	alloc:setValue(-1) -- nor should any below zero
+	alloc:setValue(-3) -- nor should any below the clamp threshold
 	lu.assertEquals(entry:getValue(), 0)
 	lu.assertIsFalse(entry.dirty)
 


### PR DESCRIPTION
sometimes we get data from the sim that is inexplicably barely outside the bounds of the control, so this helps reduce log noise and dropped updates

In this case the module in question was the F-14 - the mirrors, for whatever reason, get values slightly below zero, despite them not supporting anything below zero in modelviewer.