### PR TITLE
CI: Add datestamped version to nightly builds

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -64,6 +64,16 @@ jobs:
         run: |
           lua ./Scripts/DCS-BIOS/test/compile/LocalCompile.lua
 
+        # datestamp version for nightly builds
+      - name: prepare version
+        run: |
+          echo "CURRENT_VERSION=$(date +%Y.%m.%d)-nightly" >> $GITHUB_ENV
+
+        # replace placeholder text in version with the actual version
+      - name: set version
+        run: |
+          sed -i -e 's/"${{ env.PLACEHOLDER_VERSION }}"/"${{ env.CURRENT_VERSION }}"/g' ./Scripts/DCS-BIOS/BIOSConfig.lua
+
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.6
         with:


### PR DESCRIPTION
Fixes #1712

set version step is identical to what is used in the stable releases. prepare version is the only thing that's different.