### PR TITLE
CI: Add missing PLACEHOLDER_VERSION to nightly releases

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -38,6 +38,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
 
+    env:
+      PLACEHOLDER_VERSION: 0.0.0
+
     permissions:
       contents: write
 


### PR DESCRIPTION
The latest nightly release ran, but the version wasn't set - because `PLACEHOLDER_VERSION` doesn't exist, there was nothing for sed to replace

https://github.com/DCS-Skunkworks/dcs-bios/actions/runs/32601794386/job/97101137864#step:9:1
```
Run sed -i -e 's/""/"2026.08.22-nightly"/g' ./Scripts/DCS-BIOS/BIOSConfig.lua
  sed -i -e 's/""/"2026.08.22-nightly"/g' ./Scripts/DCS-BIOS/BIOSConfig.lua
  shell: /usr/bin/bash -e {0}
  env:
    MSYS: winsymlinks:nativestrict
    CURRENT_VERSION: 2026.08.22-nightly
```

Fixes #1712 (for real this time)

Follow up to #1749 